### PR TITLE
docker: replace docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM ubuntu:12.04
-# Let's install go just like Docker (from source).
-RUN apt-get update -q
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -qy build-essential curl git linux-libc-dev
-RUN curl -s https://storage.googleapis.com/golang/go1.3.1.src.tar.gz | tar -v -C /usr/local -xz
-RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
-ENV PATH /usr/local/go/bin:$PATH
-ADD . /opt/rudder
-RUN cd /opt/rudder && ./build

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ of etcd which maintains the overlay to actual IP mappings.
 * Step 2: Git clone the Rudder repo: ```git clone git@github.com:coreos/rudder.git```
 * Step 3: Run the build script: ```cd rudder; ./build```
 
+Alternatively, you can build rudder in a docker container with the following command. Replace $SRC with the absolute path to your rudder source code:
+
+```
+docker run -v $SRC:/opt/rudder -i -t google/golang /bin/bash -c "cd /opt/rudder && ./build"
+```
+
 ## Configuration
 
 Rudder reads its configuration from etcd. By default, it will read the configuration


### PR DESCRIPTION
The Dockerfile is misleading. If all we want to do is make it possible to build rudder with docker, just document it.
