### PR TITLE
Handle interfaces with multiples IPv4 addresses

### DIFF
--- a/pkg/ip/iface.go
+++ b/pkg/ip/iface.go
@@ -7,26 +7,6 @@ import (
 	"github.com/coreos/rudder/Godeps/_workspace/src/github.com/docker/libcontainer/netlink"
 )
 
-func GetIfaceIP4AddrMatch(iface *net.Interface, matchAddr net.IP) (net.IP, error) {
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, addr := range addrs {
-		// Attempt to parse the address in CIDR notation
-		// and assert it is IPv4
-		ip, _, err := net.ParseCIDR(addr.String())
-		if err == nil && ip.To4() != nil {
-			if ip.To4().Equal(matchAddr) {
-				return ip.To4(), nil
-			}
-		}
-	}
-
-	return nil, errors.New("No IPv4 address found for given interface")
-}
-
 func GetIfaceIP4Addr(iface *net.Interface) (net.IP, error) {
 	addrs, err := iface.Addrs()
 	if err != nil {
@@ -43,6 +23,26 @@ func GetIfaceIP4Addr(iface *net.Interface) (net.IP, error) {
 	}
 
 	return nil, errors.New("No IPv4 address found for given interface")
+}
+
+func GetIfaceIP4AddrMatch(iface *net.Interface, matchAddr net.IP) (error) {
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return err
+	}
+
+	for _, addr := range addrs {
+		// Attempt to parse the address in CIDR notation
+		// and assert it is IPv4
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err == nil && ip.To4() != nil {
+			if ip.To4().Equal(matchAddr) {
+				return nil
+			}
+		}
+	}
+
+	return errors.New("No IPv4 address found for given interface")
 }
 
 func GetDefaultGatewayIface() (*net.Interface, error) {
@@ -70,8 +70,8 @@ func GetInterfaceByIP(ip net.IP) (*net.Interface, error) {
 	}
 
 	for _, iface := range ifaces {
-		addr, err := GetIfaceIP4AddrMatch(&iface, ip)
-		if err == nil && ip.Equal(addr) {
+		err := GetIfaceIP4AddrMatch(&iface, ip)
+		if err == nil {
 			return &iface, nil
 		}
 	}


### PR DESCRIPTION
After a vagrant up of https://github.com/kelseyhightower/kubernetes-coreos my master and minions nodes have an interface with two IPv4 address:
$ ip addr show
3: enp0s8: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 08:00:27:f6:f6:a3 brd ff:ff:ff:ff:ff:ff
    inet 192.168.56.102/24 brd 192.168.56.255 scope global dynamic enp0s8
       valid_lft 1024sec preferred_lft 1024sec
    inet 172.17.8.100/24 brd 172.17.8.255 scope global enp0s8
       valid_lft forever preferred_lft forever
    inet6 fe80::a00:27ff:fef6:f6a3/64 scope link 
       valid_lft forever preferred_lft forever

$ journalctl -u rudder
Sep 16 09:36:04 minion-1 systemd[1]: Starting rudder.service...
Sep 16 09:36:04 minion-1 systemd[1]: Started rudder.service.
Sep 16 09:36:04 minion-1 rudder[957]: E0916 09:36:04.645052 00957 main.go:75] Error looking up interface 172.17.8.101: No interface with given IP found
