### PR TITLE
Use ModifiedIndex and not EtcdIndex for watches

### DIFF
--- a/subnet/subnet.go
+++ b/subnet/subnet.go
@@ -359,7 +359,7 @@ func (sm *SubnetManager) WatchLeases(receiver chan EventBatch, cancel chan bool)
 }
 
 func (sm *SubnetManager) parseSubnetWatchResponse(resp *etcd.Response) (batch *EventBatch, err error) {
-	sm.lastIndex = resp.EtcdIndex
+	sm.lastIndex = resp.Node.ModifiedIndex
 
 	sn, err := parseSubnetKey(resp.Node.Key)
 	if err != nil {


### PR DESCRIPTION
When watch returns, it's ModifiedIndex that contains
the index of the returned event. So its incremented value
should be used on next watch.

Fixes #48
