### PR TITLE
log output: fix backend initialization failed error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func run(be backend.Backend, exit chan int) {
 
 	sn, err := be.Init(iface, ipaddr, opts.ipMasq)
 	if err != nil {
-		log.Error("Could not init %v backend: %v", be.Name(), err)
+		log.Errorf("Could not init %v backend: %v", be.Name(), err)
 		return
 	}
 


### PR DESCRIPTION
Currently the output prints the %v formatting. This should use
log.Errorf instead of log.Error

Fixes #67
