### PR TITLE
Use godep command to find godep dependencies

### DIFF
--- a/backend/udp/cproxy.go
+++ b/backend/udp/cproxy.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
+	log "github.com/golang/glog"
 
 	"github.com/coreos/flannel/pkg/ip"
 )

--- a/backend/udp/udp.go
+++ b/backend/udp/udp.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink"
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
+	"github.com/vishvananda/netlink"
+	log "github.com/golang/glog"
 
 	"github.com/coreos/flannel/backend"
 	"github.com/coreos/flannel/pkg/ip"

--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -7,9 +7,9 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink"
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	log "github.com/golang/glog"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
 
 	"github.com/coreos/flannel/pkg/ip"
 )

--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"sync"
 
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink"
+	log "github.com/golang/glog"
+	"github.com/vishvananda/netlink"
 
 	"github.com/coreos/flannel/backend"
 	"github.com/coreos/flannel/subnet"

--- a/build
+++ b/build
@@ -15,7 +15,7 @@ eval $(go env)
 
 if [ ${GOOS} = "linux" ]; then
 	echo "Building flanneld..."
-	go build -o ${GOBIN}/flanneld ${REPO_PATH}
+	godep go build -o ${GOBIN}/flanneld ${REPO_PATH}
 else
 	echo "Not on Linux - skipping flanneld build"
 fi

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/go-systemd/daemon"
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
+	"github.com/coreos/go-systemd/daemon"
+	log "github.com/golang/glog"
 
 	"github.com/coreos/flannel/backend"
 	"github.com/coreos/flannel/pkg/ip"

--- a/pkg/ip/iface.go
+++ b/pkg/ip/iface.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink"
 )
 
 func GetIfaceIP4Addr(iface *net.Interface) (net.IP, error) {

--- a/subnet/registry.go
+++ b/subnet/registry.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
+	"github.com/coreos/go-etcd/etcd"
+	log "github.com/golang/glog"
 )
 
 type subnetRegistry interface {

--- a/subnet/subnet.go
+++ b/subnet/subnet.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
+	"github.com/coreos/go-etcd/etcd"
+	log "github.com/golang/glog"
 
 	"github.com/coreos/flannel/pkg/ip"
 	"github.com/coreos/flannel/pkg/task"

--- a/subnet/subnet_test.go
+++ b/subnet/subnet_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd"
+	"github.com/coreos/go-etcd/etcd"
 
 	"github.com/coreos/flannel/pkg/ip"
 )


### PR DESCRIPTION
Using godep "correctly" allows for two alternate methods to find
dependencies:
1. Use the regular $GOPATH project tree like regular go projects
2. Use the godep wrapper and use hermetic/vendored libraries in Godeps/

This change cleans up the import paths and modifies the ./build script
to use option (2).