### PR TITLE
Bug fix: base64 encoded data appeared in lease attrs

### DIFF
--- a/subnet/subnet.go
+++ b/subnet/subnet.go
@@ -424,12 +424,12 @@ func (sm *SubnetManager) parseSubnetWatchError(err error) (batch *EventBatch, ou
 }
 
 func (sm *SubnetManager) LeaseRenewer(cancel chan bool) {
-	dur := sm.leaseExp.Sub(time.Now()) - renewMargin
-
 	for {
+		dur := sm.leaseExp.Sub(time.Now()) - renewMargin
+
 		select {
 		case <-time.After(dur):
-			attrBytes, err := json.Marshal(sm.myLease.Attrs)
+			attrBytes, err := json.Marshal(&sm.myLease.Attrs)
 			if err != nil {
 				log.Error("Error renewing lease (trying again in 1 min): ", err)
 				dur = time.Minute


### PR DESCRIPTION
For some reason, json.Marshal'ing struct (vs ptr to it)
has odd interaction with json.RawMessage.

Fixes #97
