### PR TITLE
Factor out installing IP masquerading out of backends

### DIFF
--- a/backend/alloc/alloc.go
+++ b/backend/alloc/alloc.go
@@ -23,7 +23,7 @@ func New(sm *subnet.SubnetManager) backend.Backend {
 	}
 }
 
-func (m *AllocBackend) Init(extIface *net.Interface, extIP net.IP, ipMasq bool) (*backend.SubnetDef, error) {
+func (m *AllocBackend) Init(extIface *net.Interface, extIP net.IP) (*backend.SubnetDef, error) {
 	attrs := subnet.LeaseAttrs{
 		PublicIP: ip.FromIP(extIP),
 	}

--- a/backend/common.go
+++ b/backend/common.go
@@ -12,7 +12,7 @@ type SubnetDef struct {
 }
 
 type Backend interface {
-	Init(extIface *net.Interface, extIP net.IP, ipMasq bool) (*SubnetDef, error)
+	Init(extIface *net.Interface, extIP net.IP) (*SubnetDef, error)
 	Run()
 	Stop()
 	Name() string

--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -56,7 +56,7 @@ func newSubnetAttrs(pubIP net.IP, mac net.HardwareAddr) (*subnet.LeaseAttrs, err
 	}, nil
 }
 
-func (vb *VXLANBackend) Init(extIface *net.Interface, extIP net.IP, ipMasq bool) (*backend.SubnetDef, error) {
+func (vb *VXLANBackend) Init(extIface *net.Interface, extIP net.IP) (*backend.SubnetDef, error) {
 	// Parse our configuration
 	if len(vb.rawCfg) > 0 {
 		if err := json.Unmarshal(vb.rawCfg, &vb.cfg); err != nil {
@@ -102,7 +102,10 @@ func (vb *VXLANBackend) Init(extIface *net.Interface, extIP net.IP, ipMasq bool)
 		return nil, err
 	}
 
-	return &backend.SubnetDef{sn, vb.dev.MTU()}, nil
+	return &backend.SubnetDef{
+		Net: sn,
+		MTU: vb.dev.MTU(),
+	}, nil
 }
 
 func (vb *VXLANBackend) Run() {

--- a/ipmasq.go
+++ b/ipmasq.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
+
+	"github.com/coreos/flannel/pkg/ip"
+)
+
+func setupIPMasq(ipn ip.IP4Net) error {
+	ipt, err := ip.NewIPTables()
+	if err != nil {
+		return fmt.Errorf("failed to setup IP Masquerade. iptables was not found")
+	}
+
+	err = ipt.ClearChain("nat", "FLANNEL")
+	if err != nil {
+		return fmt.Errorf("Failed to create/clear FLANNEL chain in NAT table: %v", err)
+	}
+
+	rules := [][]string{
+		// This rule makes sure we don't NAT traffic within overlay network (e.g. coming out of docker0)
+		{"FLANNEL", "-d", ipn.String(), "-j", "ACCEPT"},
+		// NAT if it's not multicast traffic
+		{"FLANNEL", "!", "-d", "224.0.0.0/4", "-j", "MASQUERADE"},
+		// This rule will take everything coming from overlay and sent it to FLANNEL chain
+		{"POSTROUTING", "-s", ipn.String(), "-j", "FLANNEL"},
+	}
+
+	for _, args := range rules {
+		log.Info("Adding iptables rule: ", strings.Join(args, " "))
+
+		err = ipt.AppendUnique("nat", args...)
+		if err != nil {
+			return fmt.Errorf("Failed to insert IP masquerade rule: %v", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is an attempt to have the same IP masquerading rules
across all backends. They work purely on address ranges and
without interface names.

Practically, VXLAN now has IP masquerade support.

Fixes #101