### PR TITLE
flannel: add static configuration and subnet lease support

### DIFF
--- a/Documentation/static-configuration.md
+++ b/Documentation/static-configuration.md
@@ -1,0 +1,39 @@
+# Static Configuration Guide
+
+This guide will demonstrate how to run flannel with a static configuration and subnet lease.
+
+Why would you want to do this?
+
+Running both flannel and etcd from docker containers presents a bootstrapping problem if you want etcd to reside within the flannel overlay network.
+Using a static configuration and subnet lease you can start flannel before etcd is up.
+
+The high level steps required to make this work are as follows:
+
+* select a subnet range and reserve 1 or more subnets for static assignment (hint: use the SubnetMin flannel configuration setting) 
+* start flannel using the `-config` and `-subnet` flags
+* start docker after flannel
+* start etcd using docker
+
+When starting flannel you will need to know the IP address of the docker container to use as the `etcd-endpoint`. Using something like DNS or a Kubernetes service IP can help here.
+
+## Starting flannel with a static configuration and subnet lease
+
+```
+flanneld -config '{"Network": "10.0.0.0/8", "SubnetLen": 20, "SubnetMin": "10.10.0.4", "SubnetMax": "10.99.0.0"}' \
+  -subnet="10.10.0.0-24" \
+  -etcd-endpoints http://192.168.0.1:2379
+```
+
+Once flannel is up and running, flannel will attempt to register its lease with etcd every minute until it works. Expect to see the following log entries during this process:
+
+```
+E0225 06:45:14.164910 03447 subnet.go:474] Error renewing lease (trying again in 1 min): 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
+E0225 06:45:14.672713 03447 subnet.go:405] Watch of subnet leases failed: 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
+E0225 06:45:15.165571 03447 subnet.go:474] Error renewing lease (trying again in 1 min): 501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]
+```
+
+Once etcd is online and flannel registers its static lease, you'll see the following message in your logs:
+
+```
+I0225 06:45:17.334540 03447 subnet.go:480] Lease renewed, new expiration: 2015-02-26 14:45:16.215118532 +0000 UTC
+```

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ type CmdLineOpts struct {
 	ipMasq        bool
 	subnetFile    string
 	iface         string
+	staticSubnet  string
+	staticConfig  string
 }
 
 var opts CmdLineOpts
@@ -51,6 +53,8 @@ func init() {
 	flag.BoolVar(&opts.ipMasq, "ip-masq", false, "setup IP masquerade rule for traffic destined outside of overlay network")
 	flag.BoolVar(&opts.help, "help", false, "print this message")
 	flag.BoolVar(&opts.version, "version", false, "print version and exit")
+	flag.StringVar(&opts.staticConfig, "config", "", "static config to use")
+	flag.StringVar(&opts.staticSubnet, "subnet", "", "static subnet to use")
 }
 
 // TODO: This is yet another copy (others found in etcd, fleet) -- Pull it out!
@@ -148,7 +152,14 @@ func newSubnetManager() *subnet.SubnetManager {
 	}
 
 	for {
-		sm, err := subnet.NewSubnetManager(cfg)
+		var err error
+		var sm *subnet.SubnetManager
+		if opts.staticConfig != "" && opts.staticSubnet != "" {
+			log.Info("Using static configuration")
+			sm, err = subnet.NewSubnetManagerWithStaticConfig(opts.staticConfig, opts.staticSubnet, cfg)
+		} else {
+			sm, err = subnet.NewSubnetManager(cfg)
+		}
 		if err == nil {
 			return sm
 		}

--- a/subnet/subnet.go
+++ b/subnet/subnet.go
@@ -50,12 +50,14 @@ type SubnetLease struct {
 }
 
 type SubnetManager struct {
-	registry  subnetRegistry
-	config    *Config
-	myLease   SubnetLease
-	leaseExp  time.Time
-	lastIndex uint64
-	leases    []SubnetLease
+	registry      subnetRegistry
+	config        *Config
+	myLease       SubnetLease
+	leaseExp      time.Time
+	lastIndex     uint64
+	leases        []SubnetLease
+	staticNetwork string
+	staticConfig  *Config
 }
 
 type EventType int
@@ -75,7 +77,30 @@ func NewSubnetManager(config *EtcdConfig) (*SubnetManager, error) {
 	return newSubnetManager(esr)
 }
 
+func NewSubnetManagerWithStaticConfig(config, network string, etcdconfig *EtcdConfig) (*SubnetManager, error) {
+	esr, err := newEtcdSubnetRegistry(etcdconfig)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := ParseConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	sm := SubnetManager{
+		registry:      esr,
+		config:        cfg,
+		staticNetwork: network,
+	}
+
+	return &sm, nil
+}
+
 func (sm *SubnetManager) AcquireLease(attrs *LeaseAttrs, cancel chan bool) (ip.IP4Net, error) {
+	if sm.staticNetwork != "" {
+		return sm.useStaticLease(attrs)
+	}
+
 	for {
 		sn, err := sm.acquireLeaseOnce(attrs, cancel)
 		switch {
@@ -156,6 +181,14 @@ func (sm *SubnetManager) tryAcquireLease(extIP ip.IP4, attrs *LeaseAttrs) (ip.IP
 	default:
 		return ip.IP4Net{}, err
 	}
+}
+
+func (sm *SubnetManager) useStaticLease(attrs *LeaseAttrs) (ip.IP4Net, error) {
+	sn, err := parseSubnetKey(sm.staticNetwork)
+	sm.myLease.Network = sn
+	sm.myLease.Attrs = *attrs
+	sm.leaseExp = time.Now()
+	return sn, err
 }
 
 func (sm *SubnetManager) acquireLeaseOnce(attrs *LeaseAttrs, cancel chan bool) (ip.IP4Net, error) {


### PR DESCRIPTION
flannel can be configured with a static configuration and subnet lease.

    flanneld -config '{"Network": "10.0.0.0/8", "SubnetLen": 20, "SubnetMin": "10.10.0.4", "SubnetMax": "10.99.0.0"}' -subnet="10.10.0.0-24"

The result of this change means flannel can start without etcd. Once etcd
is online, flannel will register its lease.