### PR TITLE
Remove workaround which leaks sockets

### DIFF
--- a/subnet/registry.go
+++ b/subnet/registry.go
@@ -1,7 +1,6 @@
 package subnet
 
 import (
-	"fmt"
 	"path"
 	"sync"
 	"time"
@@ -104,9 +103,8 @@ func (esr *etcdSubnetRegistry) watchSubnets(since uint64, stop chan bool) (*etcd
 		}
 
 		if len(resp.Body) == 0 {
-			// etcd timed out, go back but recreate the client as the underlying
-			// http transport gets hosed (http://code.google.com/p/go/issues/detail?id=8648)
-			esr.resetClient()
+			// etcd timed out, and the underlying http transport gets hosed
+			// http://code.google.com/p/go/issues/detail?id=8648
 			continue
 		}
 
@@ -118,17 +116,6 @@ func (esr *etcdSubnetRegistry) client() *etcd.Client {
 	esr.mux.Lock()
 	defer esr.mux.Unlock()
 	return esr.cli
-}
-
-func (esr *etcdSubnetRegistry) resetClient() {
-	esr.mux.Lock()
-	defer esr.mux.Unlock()
-
-	var err error
-	esr.cli, err = newEtcdClient(esr.etcdCfg)
-	if err != nil {
-		panic(fmt.Errorf("resetClient: error recreating etcd client: %v", err))
-	}
 }
 
 func ensureExpiration(resp *etcd.Response, ttl uint64) {


### PR DESCRIPTION
Hello All.
This workaround over the strange issue with 300s timeouts followed by the responses with an empty body leads to a clearly visible socket leackage. For the additional details about the underlying issue see these links:

* https://github.com/golang/go/issues/8946
* https://github.com/golang/go/issues/8648

I see that this (empty body in response) no longer causes flannel to stuck so it should be better removed.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>