### PR TITLE
Retry VXLAN interface creation if it fails

### DIFF
--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -79,7 +79,8 @@ func (vb *VXLANBackend) Init(extIface *net.Interface, extIP net.IP) (*backend.Su
 		if err == nil {
 			break
 		} else {
-			log.Warning("Failed to create VXLAN interface, retrying...")
+			log.Error("VXLAN init: ", err)
+			log.Info("Retrying in 1 second...")
 
 			// wait 1 sec before retrying
 			time.Sleep(1*time.Second)

--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
 	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink"
@@ -73,9 +74,16 @@ func (vb *VXLANBackend) Init(extIface *net.Interface, extIP net.IP) (*backend.Su
 	}
 
 	var err error
-	vb.dev, err = newVXLANDevice(&devAttrs)
-	if err != nil {
-		return nil, err
+	for {
+		vb.dev, err = newVXLANDevice(&devAttrs)
+		if err == nil {
+			break
+		} else {
+			log.Warning("Failed to create VXLAN interface, retrying...")
+
+			// wait 1 sec before retrying
+			time.Sleep(1*time.Second)
+		}
 	}
 
 	sa, err := newSubnetAttrs(extIP, vb.dev.MACAddr())


### PR DESCRIPTION
Otherwise, the process can exit prematurely if flanneld is started
before the host networking configuration is not yet completed.