### PR TITLE
allow changing the default interface via the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ MTU that it supports.
 -v=0: log level for V logs. Set to 1 to see messages related to data path
 ```
 
+## Environment Variables
+Besides using the `-iface` command line option one can also change the the default interface to use
+(IP or name) for inter-host communication via the the `FLANNELD_INTERFACE` environment variable.
+Please do note that if one tries to set it both via environment and via command line whatever is
+defined in the later would win.
+
 ## Zero-downtime restarts
 When running in VXLAN mode, the kernel is providing the data path with flanneld acting as the control plane. As such, flanneld
 can be restarted (even to do an upgrade) without disturbing existing flows. However, this needs to be done in few seconds as ARP

--- a/main.go
+++ b/main.go
@@ -106,17 +106,25 @@ func lookupIface() (*net.Interface, net.IP, error) {
 	var iface *net.Interface
 	var ipaddr net.IP
 	var err error
+	default_iface := ""
 
+	// if set in bot sides command line wins
 	if len(opts.iface) > 0 {
-		if ipaddr = net.ParseIP(opts.iface); ipaddr != nil {
+		default_iface = opts.iface
+	} else if t := os.Getenv("FLANNELD_INTERFACE"); t != "" {
+		default_iface = t
+	}
+
+	if len(default_iface) > 0 {
+		if ipaddr = net.ParseIP(default_iface); ipaddr != nil {
 			iface, err = ip.GetInterfaceByIP(ipaddr)
 			if err != nil {
-				return nil, nil, fmt.Errorf("Error looking up interface %s: %s", opts.iface, err)
+				return nil, nil, fmt.Errorf("Error looking up interface %s: %s", default_iface, err)
 			}
 		} else {
-			iface, err = net.InterfaceByName(opts.iface)
+			iface, err = net.InterfaceByName(default_iface)
 			if err != nil {
-				return nil, nil, fmt.Errorf("Error looking up interface %s: %s", opts.iface, err)
+				return nil, nil, fmt.Errorf("Error looking up interface %s: %s", default_iface, err)
 			}
 		}
 	} else {


### PR DESCRIPTION
simplifies drop-ins a lot when one needs to set custom interfaces as
there isn't the need anymore to dupe the whole ExecStart thing

closes coreos/bugs#228

hi, please review... 