### PR TITLE
introduce Close interface in go-etcd and close before abandon it

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -7,8 +7,8 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",
-			"Comment": "v0.2.0-rc1-123-g0157fac",
-			"Rev": "0157fac4bb9567e843bdbb5854e966862c36be09"
+			"Comment": "v0.4.6-12-gbf30eb7",
+			"Rev": "bf30eb7162940ff9aa35d55b23e49ba69322963d"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/daemon",

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client.go
@@ -7,12 +7,16 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"strings"
 	"time"
+
+	"github.com/coreos/etcd/etcdserver/etcdhttp/httptypes"
 )
 
 // See SetConsistency for how to use these constants.
@@ -28,6 +32,10 @@ const (
 	defaultBufferSize = 10
 )
 
+func init() {
+	rand.Seed(int64(time.Now().Nanosecond()))
+}
+
 type Config struct {
 	CertFile    string        `json:"certFile"`
 	KeyFile     string        `json:"keyFile"`
@@ -40,6 +48,7 @@ type Client struct {
 	config      Config   `json:"config"`
 	cluster     *Cluster `json:"cluster"`
 	httpClient  *http.Client
+	transport   *http.Transport
 	persistence io.Writer
 	cURLch      chan string
 	// CheckRetry can be used to control the policy for failed requests
@@ -64,8 +73,7 @@ func NewClient(machines []string) *Client {
 	config := Config{
 		// default timeout is one second
 		DialTimeout: time.Second,
-		// default consistency level is STRONG
-		Consistency: STRONG_CONSISTENCY,
+		Consistency: WEAK_CONSISTENCY,
 	}
 
 	client := &Client{
@@ -89,8 +97,7 @@ func NewTLSClient(machines []string, cert, key, caCert string) (*Client, error) 
 	config := Config{
 		// default timeout is one second
 		DialTimeout: time.Second,
-		// default consistency level is STRONG
-		Consistency: STRONG_CONSISTENCY,
+		Consistency: WEAK_CONSISTENCY,
 		CertFile:    cert,
 		KeyFile:     key,
 		CaCertFile:  make([]string, 0),
@@ -166,17 +173,23 @@ func NewClientFromReader(reader io.Reader) (*Client, error) {
 // Override the Client's HTTP Transport object
 func (c *Client) SetTransport(tr *http.Transport) {
 	c.httpClient.Transport = tr
+	c.transport = tr
+}
+
+func (c *Client) Close() {
+	c.transport.DisableKeepAlives = true
+	c.transport.CloseIdleConnections()
 }
 
 // initHTTPClient initializes a HTTP client for etcd client
 func (c *Client) initHTTPClient() {
-	tr := &http.Transport{
+	c.transport = &http.Transport{
 		Dial: c.dial,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
 	}
-	c.httpClient = &http.Client{Transport: tr}
+	c.httpClient = &http.Client{Transport: c.transport}
 }
 
 // initHTTPClient initializes a HTTPS client for etcd client
@@ -292,30 +305,37 @@ func (c *Client) SyncCluster() bool {
 // internalSyncCluster syncs cluster information using the given machine list.
 func (c *Client) internalSyncCluster(machines []string) bool {
 	for _, machine := range machines {
-		httpPath := c.createHttpPath(machine, path.Join(version, "machines"))
+		httpPath := c.createHttpPath(machine, path.Join(version, "members"))
 		resp, err := c.httpClient.Get(httpPath)
 		if err != nil {
 			// try another machine in the cluster
 			continue
-		} else {
-			b, err := ioutil.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				// try another machine in the cluster
-				continue
-			}
-
-			// update Machines List
-			c.cluster.updateFromStr(string(b))
-
-			// update leader
-			// the first one in the machine list is the leader
-			c.cluster.switchLeader(0)
-
-			logger.Debug("sync.machines ", c.cluster.Machines)
-			c.saveConfig()
-			return true
 		}
+
+		b, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			// try another machine in the cluster
+			continue
+		}
+
+		var mCollection httptypes.MemberCollection
+		if err := json.Unmarshal(b, &mCollection); err != nil {
+			// try another machine
+			continue
+		}
+
+		urls := make([]string, 0)
+		for _, m := range mCollection {
+			urls = append(urls, m.ClientURLs...)
+		}
+
+		// update Machines List
+		c.cluster.updateFromStr(strings.Join(urls, ","))
+
+		logger.Debug("sync.machines ", c.cluster.Machines)
+		c.saveConfig()
+		return true
 	}
 	return false
 }

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // To pass this test, we need to create a cluster of 3 machines
-// The server should be listening on 127.0.0.1:4001, 4002, 4003
+// The server should be listening on localhost:4001, 4002, 4003
 func TestSync(t *testing.T) {
 	fmt.Println("Make sure there are three nodes at 0.0.0.0:4001-4003")
 
@@ -36,8 +36,8 @@ func TestSync(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if host != "127.0.0.1" {
-			t.Fatal("Host must be 127.0.0.1")
+		if host != "localhost" {
+			t.Fatal("Host must be localhost")
 		}
 	}
 

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/cluster.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/cluster.go
@@ -1,13 +1,14 @@
 package etcd
 
 import (
-	"net/url"
+	"math/rand"
 	"strings"
 )
 
 type Cluster struct {
 	Leader   string   `json:"leader"`
 	Machines []string `json:"machines"`
+	picked   int
 }
 
 func NewCluster(machines []string) *Cluster {
@@ -18,34 +19,16 @@ func NewCluster(machines []string) *Cluster {
 
 	// default leader and machines
 	return &Cluster{
-		Leader:   machines[0],
+		Leader:   "",
 		Machines: machines,
+		picked:   rand.Intn(len(machines)),
 	}
 }
 
-// switchLeader switch the current leader to machines[num]
-func (cl *Cluster) switchLeader(num int) {
-	logger.Debugf("switch.leader[from %v to %v]",
-		cl.Leader, cl.Machines[num])
-
-	cl.Leader = cl.Machines[num]
-}
+func (cl *Cluster) failure()     { cl.picked = rand.Intn(len(cl.Machines)) }
+func (cl *Cluster) pick() string { return cl.Machines[cl.picked] }
 
 func (cl *Cluster) updateFromStr(machines string) {
-	cl.Machines = strings.Split(machines, ", ")
-}
-
-func (cl *Cluster) updateLeader(leader string) {
-	logger.Debugf("update.leader[%s,%s]", cl.Leader, leader)
-	cl.Leader = leader
-}
-
-func (cl *Cluster) updateLeaderFromURL(u *url.URL) {
-	var leader string
-	if u.Scheme == "" {
-		leader = "http://" + u.Host
-	} else {
-		leader = u.Scheme + "://" + u.Host
-	}
-	cl.updateLeader(leader)
+	cl.Machines = strings.Split(machines, ",")
+	cl.picked = rand.Intn(len(cl.Machines))
 }

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/error.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/error.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	ErrCodeEtcdNotReachable = 501
+	ErrCodeEtcdNotReachable    = 501
+	ErrCodeUnhandledHTTPStatus = 502
 )
 
 var (

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/get.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/get.go
@@ -18,9 +18,14 @@ func (c *Client) Get(key string, sort, recursive bool) (*Response, error) {
 }
 
 func (c *Client) RawGet(key string, sort, recursive bool) (*RawResponse, error) {
+	var q bool
+	if c.config.Consistency == STRONG_CONSISTENCY {
+		q = true
+	}
 	ops := Options{
 		"recursive": recursive,
 		"sorted":    sort,
+		"quorum":    q,
 	}
 
 	return c.get(key, ops)

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/options.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/options.go
@@ -17,11 +17,11 @@ type validOptions map[string]reflect.Kind
 // values are meant to be used as constants.
 var (
 	VALID_GET_OPTIONS = validOptions{
-		"recursive":  reflect.Bool,
-		"consistent": reflect.Bool,
-		"sorted":     reflect.Bool,
-		"wait":       reflect.Bool,
-		"waitIndex":  reflect.Uint64,
+		"recursive": reflect.Bool,
+		"quorum":    reflect.Bool,
+		"sorted":    reflect.Bool,
+		"wait":      reflect.Bool,
+		"waitIndex": reflect.Uint64,
 	}
 
 	VALID_PUT_OPTIONS = validOptions{

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -39,14 +39,8 @@ func NewRawRequest(method, relativePath string, values url.Values, cancel <-chan
 // getCancelable issues a cancelable GET request
 func (c *Client) getCancelable(key string, options Options,
 	cancel <-chan bool) (*RawResponse, error) {
-	logger.Debugf("get %s [%s]", key, c.cluster.Leader)
+	logger.Debugf("get %s [%s]", key, c.cluster.pick())
 	p := keyToPath(key)
-
-	// If consistency level is set to STRONG, append
-	// the `consistent` query string.
-	if c.config.Consistency == STRONG_CONSISTENCY {
-		options["consistent"] = true
-	}
 
 	str, err := options.toParameters(VALID_GET_OPTIONS)
 	if err != nil {
@@ -73,7 +67,7 @@ func (c *Client) get(key string, options Options) (*RawResponse, error) {
 func (c *Client) put(key string, value string, ttl uint64,
 	options Options) (*RawResponse, error) {
 
-	logger.Debugf("put %s, %s, ttl: %d, [%s]", key, value, ttl, c.cluster.Leader)
+	logger.Debugf("put %s, %s, ttl: %d, [%s]", key, value, ttl, c.cluster.pick())
 	p := keyToPath(key)
 
 	str, err := options.toParameters(VALID_PUT_OPTIONS)
@@ -94,7 +88,7 @@ func (c *Client) put(key string, value string, ttl uint64,
 
 // post issues a POST request
 func (c *Client) post(key string, value string, ttl uint64) (*RawResponse, error) {
-	logger.Debugf("post %s, %s, ttl: %d, [%s]", key, value, ttl, c.cluster.Leader)
+	logger.Debugf("post %s, %s, ttl: %d, [%s]", key, value, ttl, c.cluster.pick())
 	p := keyToPath(key)
 
 	req := NewRawRequest("POST", p, buildValues(value, ttl), nil)
@@ -109,7 +103,7 @@ func (c *Client) post(key string, value string, ttl uint64) (*RawResponse, error
 
 // delete issues a DELETE request
 func (c *Client) delete(key string, options Options) (*RawResponse, error) {
-	logger.Debugf("delete %s [%s]", key, c.cluster.Leader)
+	logger.Debugf("delete %s [%s]", key, c.cluster.pick())
 	p := keyToPath(key)
 
 	str, err := options.toParameters(VALID_DELETE_OPTIONS)
@@ -130,7 +124,6 @@ func (c *Client) delete(key string, options Options) (*RawResponse, error) {
 
 // SendRequest sends a HTTP request and returns a Response as defined by etcd
 func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
-
 	var req *http.Request
 	var resp *http.Response
 	var httpPath string
@@ -194,16 +187,9 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 			}
 		}
 
-		logger.Debug("Connecting to etcd: attempt", attempt+1, "for", rr.RelativePath)
+		logger.Debug("Connecting to etcd: attempt ", attempt+1, " for ", rr.RelativePath)
 
-		if rr.Method == "GET" && c.config.Consistency == WEAK_CONSISTENCY {
-			// If it's a GET and consistency level is set to WEAK,
-			// then use a random machine.
-			httpPath = c.getHttpPath(true, rr.RelativePath)
-		} else {
-			// Else use the leader.
-			httpPath = c.getHttpPath(false, rr.RelativePath)
-		}
+		httpPath = c.getHttpPath(rr.RelativePath)
 
 		// Return a cURL command if curlChan is set
 		if c.cURLch != nil {
@@ -258,24 +244,24 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 
 		// network error, change a machine!
 		if err != nil {
-			logger.Debug("network error:", err.Error())
+			logger.Debug("network error: ", err.Error())
 			lastResp := http.Response{}
 			if checkErr := checkRetry(c.cluster, numReqs, lastResp, err); checkErr != nil {
 				return nil, checkErr
 			}
 
-			c.cluster.switchLeader(attempt % len(c.cluster.Machines))
+			c.cluster.failure()
 			continue
 		}
 
 		// if there is no error, it should receive response
-		logger.Debug("recv.response.from", httpPath)
+		logger.Debug("recv.response.from ", httpPath)
 
 		if validHttpStatusCode[resp.StatusCode] {
 			// try to read byte code and break the loop
 			respBody, err = ioutil.ReadAll(resp.Body)
 			if err == nil {
-				logger.Debug("recv.success.", httpPath)
+				logger.Debug("recv.success ", httpPath)
 				break
 			}
 			// ReadAll error may be caused due to cancel request
@@ -293,22 +279,6 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 				respBody = []byte{}
 				break
 			}
-		}
-
-		// if resp is TemporaryRedirect, set the new leader and retry
-		if resp.StatusCode == http.StatusTemporaryRedirect {
-			u, err := resp.Location()
-
-			if err != nil {
-				logger.Warning(err)
-			} else {
-				// Update cluster leader based on redirect location
-				// because it should point to the leader address
-				c.cluster.updateLeaderFromURL(u)
-				logger.Debug("recv.response.relocate", u.String())
-			}
-			resp.Body.Close()
-			continue
 		}
 
 		if checkErr := checkRetry(c.cluster, numReqs, *resp,
@@ -333,34 +303,53 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 func DefaultCheckRetry(cluster *Cluster, numReqs int, lastResp http.Response,
 	err error) error {
 
-	if numReqs >= 2*len(cluster.Machines) {
-		return newError(ErrCodeEtcdNotReachable,
-			"Tried to connect to each peer twice and failed", 0)
+	if isEmptyResponse(lastResp) {
+		if !isConnectionError(err) {
+			return err
+		}
+	} else if !shouldRetry(lastResp) {
+		body := []byte("nil")
+		if lastResp.Body != nil {
+			if b, err := ioutil.ReadAll(lastResp.Body); err == nil {
+				body = b
+			}
+		}
+		errStr := fmt.Sprintf("unhandled http status [%s] with body [%s]", http.StatusText(lastResp.StatusCode), body)
+		return newError(ErrCodeUnhandledHTTPStatus, errStr, 0)
 	}
 
-	code := lastResp.StatusCode
-	if code == http.StatusInternalServerError {
+	if numReqs > 2*len(cluster.Machines) {
+		errStr := fmt.Sprintf("failed to propose on members %v twice [last error: %v]", cluster.Machines, err)
+		return newError(ErrCodeEtcdNotReachable, errStr, 0)
+	}
+	if shouldRetry(lastResp) {
+		// sleep some time and expect leader election finish
 		time.Sleep(time.Millisecond * 200)
-
 	}
 
-	logger.Warning("bad response status code", code)
+	logger.Warning("bad response status code", lastResp.StatusCode)
 	return nil
 }
 
-func (c *Client) getHttpPath(random bool, s ...string) string {
-	var machine string
-	if random {
-		machine = c.cluster.Machines[rand.Intn(len(c.cluster.Machines))]
-	} else {
-		machine = c.cluster.Leader
-	}
+func isEmptyResponse(r http.Response) bool { return r.StatusCode == 0 }
 
-	fullPath := machine + "/" + version
+func isConnectionError(err error) bool {
+	_, ok := err.(*net.OpError)
+	return ok
+}
+
+// shouldRetry returns whether the reponse deserves retry.
+func shouldRetry(r http.Response) bool {
+	// TODO: only retry when the cluster is in leader election
+	// We cannot do it exactly because etcd doesn't support it well.
+	return r.StatusCode == http.StatusInternalServerError
+}
+
+func (c *Client) getHttpPath(s ...string) string {
+	fullPath := c.cluster.pick() + "/" + version
 	for _, seg := range s {
 		fullPath = fullPath + "/" + seg
 	}
-
 	return fullPath
 }
 
@@ -379,11 +368,13 @@ func buildValues(value string, ttl uint64) url.Values {
 	return v
 }
 
-// convert key string to http path exclude version
+// convert key string to http path exclude version, including URL escaping
 // for example: key[foo] -> path[keys/foo]
+// key[/%z] -> path[keys/%25z]
 // key[/] -> path[keys/]
 func keyToPath(key string) string {
-	p := path.Join("keys", key)
+	// URL-escape our key, except for slashes
+	p := strings.Replace(url.QueryEscape(path.Join("keys", key)), "%2F", "/", -1)
 
 	// corner case: if key is "/" or "//" ect
 	// path join will clear the tailing "/"

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/requests_test.go
@@ -1,0 +1,22 @@
+package etcd
+
+import "testing"
+
+func TestKeyToPath(t *testing.T) {
+	tests := []struct {
+		key   string
+		wpath string
+	}{
+		{"", "keys/"},
+		{"foo", "keys/foo"},
+		{"foo/bar", "keys/foo/bar"},
+		{"%z", "keys/%25z"},
+		{"/", "keys/"},
+	}
+	for i, tt := range tests {
+		path := keyToPath(tt.key)
+		if path != tt.wpath {
+			t.Errorf("#%d: path = %s, want %s", i, path, tt.wpath)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/set_curl_chan_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/set_curl_chan_test.go
@@ -19,7 +19,7 @@ func TestSetCurlChan(t *testing.T) {
 	}
 
 	expected := fmt.Sprintf("curl -X PUT %s/v2/keys/foo -d value=bar -d ttl=5",
-		c.cluster.Leader)
+		c.cluster.pick())
 	actual := c.RecvCURL()
 	if expected != actual {
 		t.Fatalf(`Command "%s" is not equal to expected value "%s"`,
@@ -32,8 +32,8 @@ func TestSetCurlChan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected = fmt.Sprintf("curl -X GET %s/v2/keys/foo?consistent=true&recursive=false&sorted=false",
-		c.cluster.Leader)
+	expected = fmt.Sprintf("curl -X GET %s/v2/keys/foo?quorum=true&recursive=false&sorted=false",
+		c.cluster.pick())
 	actual = c.RecvCURL()
 	if expected != actual {
 		t.Fatalf(`Command "%s" is not equal to expected value "%s"`,

--- a/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/set_update_create.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-etcd/etcd/set_update_create.go
@@ -13,7 +13,7 @@ func (c *Client) Set(key string, value string, ttl uint64) (*Response, error) {
 	return raw.Unmarshal()
 }
 
-// Set sets the given key to a directory.
+// SetDir sets the given key to a directory.
 // It will create a new directory or replace the old key value pair by a directory.
 // It will not replace a existing directory.
 func (c *Client) SetDir(key string, ttl uint64) (*Response, error) {

--- a/subnet/registry.go
+++ b/subnet/registry.go
@@ -139,6 +139,7 @@ func (esr *etcdSubnetRegistry) resetClient() {
 	defer esr.mux.Unlock()
 
 	var err error
+	esr.cli.Close()
 	esr.cli, err = newEtcdClient(esr.etcdCfg)
 	if err != nil {
 		panic(fmt.Errorf("resetClient: error recreating etcd client: %v", err))


### PR DESCRIPTION
Hi this PR fixes connection leaks when watching etcd built with older go version. I ran an experiment for 10 minutes each for code with/w/o this change.

Without this change:
$ sudo netstat -alpn | grep flannel
tcp        0      0 127.0.0.1:50290         127.0.0.1:4001          ESTABLISHED 28592/flannel
tcp        0      0 127.0.0.1:50266         127.0.0.1:4001          ESTABLISHED 28592/flannel
tcp        0      0 127.0.0.1:50274         127.0.0.1:4001          ESTABLISHED 28592/flannel

With this change:
$ sudo netstat -alpn | grep flannel
tcp        0      0 127.0.0.1:52912         127.0.0.1:4001          ESTABLISHED 1407/flannel