### PR TITLE
fix the bug of lost route information when restart network

### DIFF
--- a/subnet/subnet.go
+++ b/subnet/subnet.go
@@ -31,9 +31,10 @@ import (
 )
 
 const (
-	registerRetries = 10
-	subnetTTL       = 24 * 3600
-	renewMargin     = time.Hour
+	registerRetries   = 10
+	subnetTTL         = 24 * 3600
+	renewMargin       = time.Hour
+	subnetListRetries = 10
 )
 
 // etcd error codes
@@ -398,7 +399,6 @@ func (sm *SubnetManager) WatchLeases(receiver chan EventBatch, cancel chan bool)
 func (sm *SubnetManager) ListLeases(receiver chan EventBatch, cancel chan bool) {
 	//periodly list leases
 	for {
-		log.Info("begin to colletc leases")
 		resp, err := sm.registry.watchSubnets(sm.lastIndex+1, cancel)
 
 		// watchSubnets exited by cancel chan being signaled
@@ -418,14 +418,11 @@ func (sm *SubnetManager) ListLeases(receiver chan EventBatch, cancel chan bool) 
 
 				batch = append(batch, Event{SubnetListed, l})
 			}
-			log.Info("finish collection leases")
 			if &batch != nil {
 				receiver <- batch
 			}
-
-			log.Info("finish passing")
 		}
-		time.Sleep(10 * time.Second)
+		time.Sleep(subnetListRetries * time.Second)
 	}
 }
 


### PR DESCRIPTION
hostgw: fix the bug of lost route infomation when restart network

when we're using flannel with hostgw backend, if we unplug the network cable and then plug the network cable immediately, we find the route infomation will be lost and can never be recovered.  and of course we can not be routed to containers in other minor with k8s.  Our fix periodly check the routes information, and will fix it when route information lost.

   
 