### PR TITLE
properly handle nil cursor and use Etcd vs Modified index

### DIFF
--- a/subnet/etcd.go
+++ b/subnet/etcd.go
@@ -245,10 +245,11 @@ func (m *EtcdManager) getLeases(ctx context.Context, network string) ([]Lease, u
 				}
 			}
 		}
-		index = resp.Node.ModifiedIndex
+		index = resp.EtcdIndex
 
 	case err.(*etcd.EtcdError).ErrorCode == etcdKeyNotFound:
 		// key not found: treat it as empty set
+		index = resp.EtcdIndex
 
 	default:
 		return nil, 0, err
@@ -274,11 +275,11 @@ func (m *EtcdManager) RenewLease(ctx context.Context, network string, lease *Lea
 }
 
 func (m *EtcdManager) WatchLeases(ctx context.Context, network string, cursor interface{}) (WatchResult, error) {
-	nextIndex := uint64(0)
-	if cursor != nil {
-		nextIndex = cursor.(uint64)
+	if cursor == nil {
+		return m.watchReset(ctx, network)
 	}
 
+	nextIndex := cursor.(uint64)
 	resp, err := m.registry.watchSubnets(ctx, network, nextIndex)
 
 	switch {

--- a/subnet/subnet_test.go
+++ b/subnet/subnet_test.go
@@ -77,13 +77,13 @@ func TestWatchLeaseAdded(t *testing.T) {
 	events := make(chan []Event)
 	go WatchLeases(ctx, sm, "", events)
 
+	// skip over the initial snapshot
+	<-events
+
 	expected := "10.3.3.0-24"
 	msr.createSubnet(ctx, "_", expected, `{"PublicIP": "1.1.1.1"}`, 0)
 
-	evtBatch, ok := <-events
-	if !ok {
-		t.Fatalf("WatchSubnets did not publish")
-	}
+	evtBatch := <-events
 
 	if len(evtBatch) != 1 {
 		t.Fatalf("WatchSubnets produced wrong sized event batch")
@@ -111,13 +111,13 @@ func TestWatchLeaseRemoved(t *testing.T) {
 	events := make(chan []Event)
 	go WatchLeases(ctx, sm, "", events)
 
+	// skip over the initial snapshot
+	<-events
+
 	expected := "10.3.4.0-24"
 	msr.expireSubnet(expected)
 
-	evtBatch, ok := <-events
-	if !ok {
-		t.Fatalf("WatchSubnets did not publish")
-	}
+	evtBatch := <-events
 
 	if len(evtBatch) != 1 {
 		t.Fatalf("WatchSubnets produced wrong sized event batch")


### PR DESCRIPTION
This fixes two bugs:
1. watch was not getting a snapshot with nil cursor.
2. watch was not advancing properly due to wrong index used.