### PR TITLE
Update release tools

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,18 @@
+## Doing a release
+
+To do a release, e.g. version 0.5.0, do the following steps.
+This assumes that the remote that's hosting the project (i.e. https://github.com/coreos/flannel) is named "upstream".
+
+```
+VER=0.5.0
+cd ./dist`
+
+# Make two commits: v0.5.0 and v0.5.0+git; create a tag v0.5.0; push commits and tags to $ORIGIN
+ORIGIN=upstream ./bump-release.sh $VER
+
+# Build docker, ACI images and tarball
+./build-release.sh $VER
+
+# Publish to quay.io (credentials required)
+./publish.sh $VER
+```

--- a/dist/build-docker.sh
+++ b/dist/build-docker.sh
@@ -11,7 +11,7 @@ tag=$1
 tgt=$(mktemp -d)
 
 # Build flannel inside 
-docker run -v `pwd`/../:/opt/flannel -i -t golang:1.4.1 /bin/bash -c "cd /opt/flannel && ./build"
+docker run -v `pwd`/../:/opt/flannel -i -t golang:1.4.2 /bin/bash -c "cd /opt/flannel && ./build"
 
 # Generate Dockerfile into target tmp dir
 cat <<DF >${tgt}/Dockerfile

--- a/dist/build-release.sh
+++ b/dist/build-release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+function usage {
+	echo "Usage: $0 <version>"
+	exit 1
+}
+
+function package_tarball {
+	builddir="flannel-$VER"
+	tarball="flannel-${VER}-${GOOS}-${GOARCH}.tar.gz"
+
+	mkdir -p $builddir
+	cp ../bin/flanneld ./mk-docker-opts.sh ../README.md $builddir
+
+	tar cvvfz $tarball "flannel-$VER"
+}
+
+VER="$1"
+GOARCH="amd64"
+GOOS="linux"
+
+if [ "$VER" == "" ]; then
+	usage
+fi
+
+cur_branch=$(git rev-parse --abbrev-ref HEAD)
+git checkout v$VER
+
+./build-docker.sh $VER
+./build-aci.sh $VER
+package_tarball
+
+# restore the branch
+git checkout $cur_branch

--- a/dist/bump-release.sh
+++ b/dist/bump-release.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -eu
+#
+# $1 = version string (e.g. 0.8.0)
+
+VERSION="${1:?version must be set}"
+if [ "${VERSION:0:1}" == "v" ]; then
+	echo "version tag shouldn't start with v" >> /dev/stderr
+	exit 255
+fi
+ORIGIN="${ORIGIN:=upstream}"
+VERSIONTAG="v${VERSION}"
+
+TAGBR="v${VERSION}-tag"
+
+replace_version() {
+	sed -i -e "s/const Version.*/const Version = \"$1\"/" ../version.go
+	git commit -m "version: bump to v$1" ../version.go
+}
+
+# make sure we're up to date
+git pull --ff-only ${ORIGIN} master
+
+# tag it
+replace_version ${VERSION}
+git tag -a -m "${VERSIONTAG}" "${VERSIONTAG}"
+
+# bump ver to +git and push to origin
+replace_version "${VERSION}+git"
+git push "${ORIGIN}" master
+
+# push the tag
+git push "${ORIGIN}" "${VERSIONTAG}"
+
+echo
+echo "============================================================"
+echo "Tagged $VERSIONTAG in $ORIGIN"
+echo "Now run \"build-release.sh $VERSION\""
+echo


### PR DESCRIPTION
- Add README.md to document how to do a release
- Switch to using GO 1.4.2
- Add scripts to bump/tag a release