### PR TITLE
Don't allow extra args

### DIFF
--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func main() {
 	// now parse command line args
 	flag.Parse()
 
-	if opts.help {
+	if flag.NArg() > 0 || opts.help {
 		fmt.Fprintf(os.Stderr, "Usage: %s [OPTION]...\n", os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(0)


### PR DESCRIPTION
Related to #216  ... If you mistakenly forget to add the right arg names to  flannel , then it just silently ignores them.  that causes alot of confusion .  Lets fail if there are wrong/bad/unknown/ignored args sent in, and fail fast.