### PR TITLE
prevent failed builds from being shadowed by old working builds

### DIFF
--- a/build
+++ b/build
@@ -13,9 +13,16 @@ export GOPATH=${PWD}/gopath
 
 eval $(go env)
 
-if [ ${GOOS} = "linux" ]; then
-	echo "Building flanneld..."
-	go build -o ${GOBIN}/flanneld ${REPO_PATH}
+if [ -f $GOBIN/flanneld ]; then
+    echo "Aborting build : remove old $GOBIN/flanneld first!"
+    exit 1
 else
-	echo "Not on Linux - skipping flanneld build"
+    echo "$GOBIN/flanneld not exist"
+fi
+
+if [ ${GOOS} = "linux" ]; then
+    echo "Building flanneld for OS ${GOOS} to dir $perm_build..."
+    go build -o $GOBIN/flanneld ${REPO_PATH}
+else
+    echo "Not on linux/*nix, ${GOOS} - skipping flanneld build"
 fi


### PR DESCRIPTION
Minor put important improvement to prevent binary failed builds shadowed by old builds