### PR TITLE
Ignore route to local ext IP in hostgw mode

### DIFF
--- a/backend/hostgw/hostgw.go
+++ b/backend/hostgw/hostgw.go
@@ -145,6 +145,9 @@ func (rb *HostgwBackend) handleSubnetEvents(batch []subnet.Event) {
 				Gw:        evt.Lease.Attrs.PublicIP.ToIP(),
 				LinkIndex: rb.extIface.Index,
 			}
+			if rb.extIP.Equal(route.Gw) {
+				continue
+			}
 			if err := netlink.RouteAdd(&route); err != nil {
 				log.Errorf("Error adding route to %v via %v: %v", evt.Lease.Subnet, evt.Lease.Attrs.PublicIP, err)
 				continue


### PR DESCRIPTION
Route to local ext IP may get added when local docker0 is not yet setup, see:

[root@localhost ~]# ip route
default via 10.0.2.2 dev enp0s3
10.0.2.0/24 dev enp0s3  proto kernel  scope link  src 10.0.2.15
**10.10.176.0/20 via 172.17.8.101 dev enp0s8**
**10.10.176.0/20 dev docker0  proto kernel  scope link  src 10.10.176.1**
10.10.192.0/20 via 172.17.8.102 dev enp0s8
10.15.240.0/20 via 172.17.8.100 dev enp0s8
169.254.0.0/16 dev enp0s3  scope link  metric 1002
169.254.0.0/16 dev enp0s8  scope link  metric 1003
172.17.8.0/24 dev enp0s8  proto kernel  scope link  src 172.17.8.101
