### PR TITLE
Ignore own lease in subnet events

### DIFF
--- a/backend/hostgw/hostgw.go
+++ b/backend/hostgw/hostgw.go
@@ -101,7 +101,7 @@ func (rb *HostgwBackend) Run() {
 	evts := make(chan []subnet.Event)
 	rb.wg.Add(1)
 	go func() {
-		subnet.WatchLeases(rb.ctx, rb.sm, rb.network, evts)
+		subnet.WatchLeases(rb.ctx, rb.sm, rb.network, rb.lease, evts)
 		rb.wg.Done()
 	}()
 
@@ -148,9 +148,6 @@ func (rb *HostgwBackend) handleSubnetEvents(batch []subnet.Event) {
 				Dst:       evt.Lease.Subnet.ToIPNet(),
 				Gw:        evt.Lease.Attrs.PublicIP.ToIP(),
 				LinkIndex: rb.extIface.Index,
-			}
-			if rb.extIaddr.Equal(route.Gw) {
-				continue
 			}
 			if err := netlink.RouteAdd(&route); err != nil {
 				log.Errorf("Error adding route to %v via %v: %v", evt.Lease.Subnet, evt.Lease.Attrs.PublicIP, err)

--- a/backend/udp/udp.go
+++ b/backend/udp/udp.go
@@ -225,7 +225,7 @@ func (m *UdpBackend) monitorEvents() {
 
 	m.wg.Add(1)
 	go func() {
-		subnet.WatchLeases(m.ctx, m.sm, m.network, evts)
+		subnet.WatchLeases(m.ctx, m.sm, m.network, m.lease, evts)
 		m.wg.Done()
 	}()
 

--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -160,7 +160,7 @@ func (vb *VXLANBackend) Run() {
 	evts := make(chan []subnet.Event)
 	vb.wg.Add(1)
 	go func() {
-		subnet.WatchLeases(vb.ctx, vb.sm, vb.network, evts)
+		subnet.WatchLeases(vb.ctx, vb.sm, vb.network, vb.lease, evts)
 		log.Info("WatchLeases exited")
 		vb.wg.Done()
 	}()

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -134,7 +134,7 @@ func doTestWatch(t *testing.T, sm subnet.Manager) {
 
 	events := make(chan []subnet.Event)
 	go func() {
-		subnet.WatchLeases(ctx, sm, "_", events)
+		subnet.WatchLeases(ctx, sm, "_", nil, events)
 		wg.Done()
 	}()
 


### PR DESCRIPTION
Add an option to ignore a lease in WatchLeases.
Backends can pass their own lease so filter out events
related to them.

Fixes #241 and #126