### PR TITLE
Refactoring: single ctx and pull out LeaseRenewer

### DIFF
--- a/backend/alloc/alloc.go
+++ b/backend/alloc/alloc.go
@@ -14,33 +14,27 @@ type AllocBackend struct {
 	sm      subnet.Manager
 	network string
 	lease   *subnet.Lease
-	ctx     context.Context
-	cancel  context.CancelFunc
 }
 
 func New(sm subnet.Manager, network string) backend.Backend {
-	ctx, cancel := context.WithCancel(context.Background())
-
 	return &AllocBackend{
 		sm:      sm,
 		network: network,
-		ctx:     ctx,
-		cancel:  cancel,
 	}
 }
 
-func (m *AllocBackend) Init(extIface *net.Interface, extIaddr net.IP, extEaddr net.IP) (*backend.SubnetDef, error) {
+func (m *AllocBackend) Init(ctx context.Context, extIface *net.Interface, extIaddr net.IP, extEaddr net.IP) (*backend.SubnetDef, error) {
 	attrs := subnet.LeaseAttrs{
 		PublicIP: ip.FromIP(extEaddr),
 	}
 
-	l, err := m.sm.AcquireLease(m.ctx, m.network, &attrs)
+	l, err := m.sm.AcquireLease(ctx, m.network, &attrs)
 	switch err {
 	case nil:
 		m.lease = l
 		return &backend.SubnetDef{
-			Net: l.Subnet,
-			MTU: extIface.MTU,
+			Lease: l,
+			MTU:   extIface.MTU,
 		}, nil
 
 	case context.Canceled, context.DeadlineExceeded:
@@ -51,14 +45,5 @@ func (m *AllocBackend) Init(extIface *net.Interface, extIaddr net.IP, extEaddr n
 	}
 }
 
-func (m *AllocBackend) Run() {
-	subnet.LeaseRenewer(m.ctx, m.sm, m.network, m.lease)
-}
-
-func (m *AllocBackend) Stop() {
-	m.cancel()
-}
-
-func (m *AllocBackend) Name() string {
-	return "allocation"
+func (m *AllocBackend) Run(ctx context.Context) {
 }

--- a/backend/common.go
+++ b/backend/common.go
@@ -17,17 +17,17 @@ package backend
 import (
 	"net"
 
-	"github.com/coreos/flannel/pkg/ip"
+	"github.com/coreos/flannel/Godeps/_workspace/src/golang.org/x/net/context"
+
+	"github.com/coreos/flannel/subnet"
 )
 
 type SubnetDef struct {
-	Net ip.IP4Net
-	MTU int
+	Lease *subnet.Lease
+	MTU   int
 }
 
 type Backend interface {
-	Init(extIface *net.Interface, extIaddr net.IP, extEaddr net.IP) (*SubnetDef, error)
-	Run()
-	Stop()
-	Name() string
+	Init(ctx context.Context, extIface *net.Interface, extIaddr net.IP, extEaddr net.IP) (*SubnetDef, error)
+	Run(ctx context.Context)
 }

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func init() {
 	flag.BoolVar(&opts.version, "version", false, "print version and exit")
 }
 
-func writeSubnetFile(path string, nw ip.IP4Net, sn *backend.SubnetDef) error {
+func writeSubnetFile(path string, nw ip.IP4Net, sd *backend.SubnetDef) error {
 	dir, name := filepath.Split(path)
 	os.MkdirAll(dir, 0755)
 
@@ -93,11 +93,12 @@ func writeSubnetFile(path string, nw ip.IP4Net, sn *backend.SubnetDef) error {
 
 	// Write out the first usable IP by incrementing
 	// sn.IP by one
-	sn.Net.IP += 1
+	sn := sd.Lease.Subnet
+	sn.IP += 1
 
 	fmt.Fprintf(f, "FLANNEL_NETWORK=%s\n", nw)
-	fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn.Net)
-	fmt.Fprintf(f, "FLANNEL_MTU=%d\n", sn.MTU)
+	fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn)
+	fmt.Fprintf(f, "FLANNEL_MTU=%d\n", sd.MTU)
 	_, err = fmt.Fprintf(f, "FLANNEL_IPMASQ=%v\n", opts.ipMasq)
 	f.Close()
 	if err != nil {

--- a/network/backend.go
+++ b/network/backend.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -16,19 +15,7 @@ import (
 )
 
 func newBackend(sm subnet.Manager, network string, config *subnet.Config) (backend.Backend, error) {
-	var bt struct {
-		Type string
-	}
-
-	if len(config.Backend) == 0 {
-		bt.Type = "udp"
-	} else {
-		if err := json.Unmarshal(config.Backend, &bt); err != nil {
-			return nil, fmt.Errorf("Error decoding Backend property of config: %v", err)
-		}
-	}
-
-	switch strings.ToLower(bt.Type) {
+	switch strings.ToLower(config.BackendType) {
 	case "udp":
 		return udp.New(sm, network, config), nil
 	case "alloc":
@@ -42,6 +29,6 @@ func newBackend(sm subnet.Manager, network string, config *subnet.Config) (backe
 	case "gce":
 		return gce.New(sm, network, config), nil
 	default:
-		return nil, fmt.Errorf("%v: '%v': unknown backend type", network, bt.Type)
+		return nil, fmt.Errorf("%v: '%v': unknown backend type", network, config.BackendType)
 	}
 }


### PR DESCRIPTION
- Use a single copy of ctx and plumb it throughout.
This fixes the left over artifact that ctx went into
flannel in stages.

- Backends being responsible for lease renewal is
not really valuable and just leads to duplication.