### PR TITLE
Bug fix: remote mode errors out with bad backend type

### DIFF
--- a/remote/client.go
+++ b/remote/client.go
@@ -103,8 +103,13 @@ func (m *RemoteManager) GetNetworkConfig(ctx context.Context, network string) (*
 		return nil, httpError(resp)
 	}
 
-	config := &subnet.Config{}
-	if err := json.NewDecoder(resp.Body).Decode(config); err != nil {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := subnet.ParseConfig(string(body))
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Due to code reorg, the config must now be parsed via
subnet.ParseConfig in remote client.