### PR TITLE
Add support for singleton backends

### DIFF
--- a/backend/alloc/alloc.go
+++ b/backend/alloc/alloc.go
@@ -16,7 +16,7 @@ type AllocBackend struct {
 	lease   *subnet.Lease
 }
 
-func New(sm subnet.Manager, network string) backend.Backend {
+func New(sm subnet.Manager, network string, config *subnet.Config) backend.Backend {
 	return &AllocBackend{
 		sm:      sm,
 		network: network,

--- a/backend/common.go
+++ b/backend/common.go
@@ -15,8 +15,6 @@
 package backend
 
 import (
-	"net"
-
 	"github.com/coreos/flannel/Godeps/_workspace/src/golang.org/x/net/context"
 
 	"github.com/coreos/flannel/subnet"
@@ -27,7 +25,21 @@ type SubnetDef struct {
 	MTU   int
 }
 
+// Besides the entry points in the Backend interface, the backend's New()
+// function receives static network interface information (like internal and
+// external IP addresses, MTU, etc) which it should cache for later use if
+// needed.
+//
+// To implement a singleton backend which manages multiple networks, the
+// New() function should create the singleton backend object once, and return
+// that object on on further calls to New().  The backend is guaranteed that
+// the arguments passed via New() will not change across invocations.  Also,
+// since multiple RegisterNetwork() and Run() calls may be in-flight at any
+// given time for a singleton backend, it must protect these calls with a mutex.
 type Backend interface {
-	Init(ctx context.Context, extIface *net.Interface, extIaddr net.IP, extEaddr net.IP) (*SubnetDef, error)
+	// Called when the backend should create or begin managing a new network
+	RegisterNetwork(ctx context.Context, network string, config *subnet.Config) (*SubnetDef, error)
+	// Called after the backend's first network has been registered to
+	// allow the plugin to watch dynamic events
 	Run(ctx context.Context)
 }

--- a/backend/hostgw/hostgw.go
+++ b/backend/hostgw/hostgw.go
@@ -42,7 +42,7 @@ type HostgwBackend struct {
 	rl       []netlink.Route
 }
 
-func New(sm subnet.Manager, network string) backend.Backend {
+func New(sm subnet.Manager, network string, config *subnet.Config) backend.Backend {
 	b := &HostgwBackend{
 		sm:      sm,
 		network: network,

--- a/network/network.go
+++ b/network/network.go
@@ -57,9 +57,9 @@ func (n *Network) Init(ctx context.Context, iface *net.Interface, iaddr net.IP, 
 		},
 
 		func() (err error) {
-			be, err = newBackend(n.sm, n.Name, n.Config)
+			be, err = newBackend(n.sm, n.Config.BackendType, iface, iaddr, eaddr)
 			if err != nil {
-				log.Error("Failed to create backend: ", err)
+				log.Errorf("Failed to create and initialize network %v (type %v): %v", n.Name, n.Config.BackendType, err)
 			} else {
 				n.be = be
 			}
@@ -67,11 +67,12 @@ func (n *Network) Init(ctx context.Context, iface *net.Interface, iaddr net.IP, 
 		},
 
 		func() (err error) {
-			sn, err = be.Init(ctx, iface, iaddr, eaddr)
+			sn, err = be.RegisterNetwork(ctx, n.Name, n.Config)
 			if err != nil {
-				log.Errorf("Failed to initialize network %v (type %v): %v", n.Name, n.Config.BackendType, err)
+				log.Errorf("Failed register network %v (type %v): %v", n.Name, n.Config.BackendType, err)
+			} else {
+				n.lease = sn.Lease
 			}
-			n.lease = sn.Lease
 			return
 		},
 


### PR DESCRIPTION
We'd like to implement our multitenant OVS backend with a singleton object to set up and create the OVS bridge (we only need one bridge for all tenant networks) and maintain some host-wide flows.  To decrease the complexity of a singleton backend we can very slightly increase the complexity of non-singleton backends by splitting Init() into:

1) Init() which takes properties that won't ever change (ctx, interface properties, etc)
2) AddNetwork() which tells the backend to actually configure itself for the network

A singleton backend will now only be created once, and have its Init() only called once.  After that, each new Network object will trigger an AddNetwork() call to poke the singleton backend to do whatever it needs to do for the new network.

(once the add/remove networks branch lands, of course we'll also have a RemoveNetwork() call into the backend, which non-singleton backends would ignore...)