### PR TITLE
etcd node and error return handling fixups

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -27,8 +27,13 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/client",
-			"Comment": "v2.1.1-85-gff0b872",
-			"Rev": "ff0b8723c747e76d2651bcddaff26563128ab216"
+			"Comment": "v2.1.1-135-ga1ef699",
+			"Rev": "a1ef699aebbe7ebb4da2f90a42e0f612eec08384"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/pathutil",
+			"Comment": "v2.1.1-135-ga1ef699",
+			"Rev": "a1ef699aebbe7ebb4da2f90a42e0f612eec08384"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/transport",

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/cancelreq.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/cancelreq.go
@@ -1,0 +1,20 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// borrowed from golang/net/context/ctxhttp/cancelreq.go
+
+// +build go1.5
+
+package client
+
+import "net/http"
+
+func requestCanceler(tr CancelableTransport, req *http.Request) func() {
+	ch := make(chan struct{})
+	req.Cancel = ch
+
+	return func() {
+		close(ch)
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/cancelreq_go14.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/cancelreq_go14.go
@@ -1,0 +1,17 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// borrowed from golang/net/context/ctxhttp/cancelreq_go14.go
+
+// +build !go1.5
+
+package client
+
+import "net/http"
+
+func requestCanceler(tr CancelableTransport, req *http.Request) func() {
+	return func() {
+		tr.CancelRequest(req)
+	}
+}

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/client.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/client.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
+	"sort"
 	"sync"
 	"time"
 
@@ -85,6 +87,23 @@ type Config struct {
 	// Password is the password for the specified user to add as an authorization header
 	// to the request.
 	Password string
+
+	// HeaderTimeoutPerRequest specifies the time limit to wait for response
+	// header in a single request made by the Client. The timeout includes
+	// connection time, any redirects, and header wait time.
+	//
+	// For non-watch GET request, server returns the response body immediately.
+	// For PUT/POST/DELETE request, server will attempt to commit request
+	// before responding, which is expected to take `100ms + 2 * RTT`.
+	// For watch request, server returns the header immediately to notify Client
+	// watch start. But if server is behind some kind of proxy, the response
+	// header may be cached at proxy, and Client cannot rely on this behavior.
+	//
+	// One API call may send multiple requests to different etcd servers until it
+	// succeeds. Use context of the API to specify the overall timeout.
+	//
+	// A HeaderTimeoutPerRequest of zero means no timeout.
+	HeaderTimeoutPerRequest time.Duration
 }
 
 func (cfg *Config) transport() CancelableTransport {
@@ -122,6 +141,22 @@ type Client interface {
 	// Sync updates the internal cache of the etcd cluster's membership.
 	Sync(context.Context) error
 
+	// AutoSync periodically calls Sync() every given interval.
+	// The recommended sync interval is 10 seconds to 1 minute, which does
+	// not bring too much overhead to server and makes client catch up the
+	// cluster change in time.
+	//
+	// The example to use it:
+	//
+	//  for {
+	//      err := client.AutoSync(ctx, 10*time.Second)
+	//      if err == context.DeadlineExceeded || err == context.Canceled {
+	//          break
+	//      }
+	//      log.Print(err)
+	//  }
+	AutoSync(context.Context, time.Duration) error
+
 	// Endpoints returns a copy of the current set of API endpoints used
 	// by Client to resolve HTTP requests. If Sync has ever been called,
 	// this may differ from the initial Endpoints provided in the Config.
@@ -132,7 +167,7 @@ type Client interface {
 
 func New(cfg Config) (Client, error) {
 	c := &httpClusterClient{
-		clientFactory: newHTTPClientFactory(cfg.transport(), cfg.checkRedirect()),
+		clientFactory: newHTTPClientFactory(cfg.transport(), cfg.checkRedirect(), cfg.HeaderTimeoutPerRequest),
 		rand:          rand.New(rand.NewSource(int64(time.Now().Nanosecond()))),
 	}
 	if cfg.Username != "" {
@@ -151,13 +186,14 @@ type httpClient interface {
 	Do(context.Context, httpAction) (*http.Response, []byte, error)
 }
 
-func newHTTPClientFactory(tr CancelableTransport, cr CheckRedirectFunc) httpClientFactory {
+func newHTTPClientFactory(tr CancelableTransport, cr CheckRedirectFunc, headerTimeout time.Duration) httpClientFactory {
 	return func(ep url.URL) httpClient {
 		return &redirectFollowingHTTPClient{
 			checkRedirect: cr,
 			client: &simpleHTTPClient{
-				transport: tr,
-				endpoint:  ep,
+				transport:     tr,
+				endpoint:      ep,
+				headerTimeout: headerTimeout,
 			},
 		}
 	}
@@ -239,14 +275,20 @@ func (c *httpClusterClient) Do(ctx context.Context, act httpAction) (*http.Respo
 		resp, body, err = hc.Do(ctx, action)
 		if err != nil {
 			cerr.Errors = append(cerr.Errors, err)
-			if err == context.DeadlineExceeded || err == context.Canceled {
-				return nil, nil, cerr
+			// mask previous errors with context error, which is controlled by user
+			if err == context.Canceled || err == context.DeadlineExceeded {
+				return nil, nil, err
 			}
 			continue
 		}
 		if resp.StatusCode/100 == 5 {
-			// TODO: make sure this is a no leader response
-			cerr.Errors = append(cerr.Errors, fmt.Errorf("client: etcd member %s has no leader", eps[k].String()))
+			switch resp.StatusCode {
+			case http.StatusInternalServerError, http.StatusServiceUnavailable:
+				// TODO: make sure this is a no leader response
+				cerr.Errors = append(cerr.Errors, fmt.Errorf("client: etcd member %s has no leader", eps[k].String()))
+			default:
+				cerr.Errors = append(cerr.Errors, fmt.Errorf("client: etcd member %s returns server error [%s]", eps[k].String(), http.StatusText(resp.StatusCode)))
+			}
 			continue
 		}
 		if k != pinned {
@@ -286,8 +328,36 @@ func (c *httpClusterClient) Sync(ctx context.Context) error {
 	for _, m := range ms {
 		eps = append(eps, m.ClientURLs...)
 	}
+	sort.Sort(sort.StringSlice(eps))
+
+	ceps := make([]string, len(c.endpoints))
+	for i, cep := range c.endpoints {
+		ceps[i] = cep.String()
+	}
+	sort.Sort(sort.StringSlice(ceps))
+	// fast path if no change happens
+	// this helps client to pin the endpoint when no cluster change
+	if reflect.DeepEqual(eps, ceps) {
+		return nil
+	}
 
 	return c.reset(eps)
+}
+
+func (c *httpClusterClient) AutoSync(ctx context.Context, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		err := c.Sync(ctx)
+		if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 type roundTripResponse struct {
@@ -296,8 +366,9 @@ type roundTripResponse struct {
 }
 
 type simpleHTTPClient struct {
-	transport CancelableTransport
-	endpoint  url.URL
+	transport     CancelableTransport
+	endpoint      url.URL
+	headerTimeout time.Duration
 }
 
 func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Response, []byte, error) {
@@ -306,6 +377,14 @@ func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Respon
 	if err := printcURL(req); err != nil {
 		return nil, nil, err
 	}
+
+	hctx, hcancel := context.WithCancel(ctx)
+	if c.headerTimeout > 0 {
+		hctx, hcancel = context.WithTimeout(ctx, c.headerTimeout)
+	}
+	defer hcancel()
+
+	reqcancel := requestCanceler(c.transport, req)
 
 	rtchan := make(chan roundTripResponse, 1)
 	go func() {
@@ -320,12 +399,19 @@ func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Respon
 	select {
 	case rtresp := <-rtchan:
 		resp, err = rtresp.resp, rtresp.err
-	case <-ctx.Done():
+	case <-hctx.Done():
 		// cancel and wait for request to actually exit before continuing
-		c.transport.CancelRequest(req)
+		reqcancel()
 		rtresp := <-rtchan
 		resp = rtresp.resp
-		err = ctx.Err()
+		switch {
+		case ctx.Err() != nil:
+			err = ctx.Err()
+		case hctx.Err() != nil:
+			err = fmt.Errorf("client: endpoint %s exceeded header timeout", c.endpoint.String())
+		default:
+			panic("failed to get error from context")
+		}
 	}
 
 	// always check for resp nil-ness to deal with possible
@@ -349,11 +435,9 @@ func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Respon
 
 	select {
 	case <-ctx.Done():
-		err = resp.Body.Close()
+		resp.Body.Close()
 		<-done
-		if err == nil {
-			err = ctx.Err()
-		}
+		return nil, nil, ctx.Err()
 	case <-done:
 	}
 

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/keys_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/keys_test.go
@@ -80,6 +80,20 @@ func TestV2KeysURLHelper(t *testing.T) {
 			key:      "/baz",
 			want:     url.URL{Scheme: "https", Host: "example.com", Path: "/foo/bar/baz"},
 		},
+		// Prefix is joined to path
+		{
+			endpoint: url.URL{Scheme: "https", Host: "example.com", Path: "/foo"},
+			prefix:   "/bar",
+			key:      "",
+			want:     url.URL{Scheme: "https", Host: "example.com", Path: "/foo/bar"},
+		},
+		// Keep trailing slash
+		{
+			endpoint: url.URL{Scheme: "https", Host: "example.com", Path: "/foo"},
+			prefix:   "/bar",
+			key:      "/baz/",
+			want:     url.URL{Scheme: "https", Host: "example.com", Path: "/foo/bar/baz/"},
+		},
 	}
 
 	for i, tt := range tests {
@@ -91,7 +105,7 @@ func TestV2KeysURLHelper(t *testing.T) {
 }
 
 func TestGetAction(t *testing.T) {
-	ep := url.URL{Scheme: "http", Host: "example.com/v2/keys"}
+	ep := url.URL{Scheme: "http", Host: "example.com", Path: "/v2/keys"}
 	baseWantURL := &url.URL{
 		Scheme: "http",
 		Host:   "example.com",
@@ -157,7 +171,7 @@ func TestGetAction(t *testing.T) {
 }
 
 func TestWaitAction(t *testing.T) {
-	ep := url.URL{Scheme: "http", Host: "example.com/v2/keys"}
+	ep := url.URL{Scheme: "http", Host: "example.com", Path: "/v2/keys"}
 	baseWantURL := &url.URL{
 		Scheme: "http",
 		Host:   "example.com",
@@ -207,7 +221,7 @@ func TestWaitAction(t *testing.T) {
 
 func TestSetAction(t *testing.T) {
 	wantHeader := http.Header(map[string][]string{
-		"Content-Type": []string{"application/x-www-form-urlencoded"},
+		"Content-Type": {"application/x-www-form-urlencoded"},
 	})
 
 	tests := []struct {
@@ -269,7 +283,7 @@ func TestSetAction(t *testing.T) {
 			act: setAction{
 				Key: "/foo/",
 			},
-			wantURL:  "http://example.com/foo",
+			wantURL:  "http://example.com/foo/",
 			wantBody: "value=",
 		},
 
@@ -398,7 +412,7 @@ func TestSetAction(t *testing.T) {
 
 func TestCreateInOrderAction(t *testing.T) {
 	wantHeader := http.Header(map[string][]string{
-		"Content-Type": []string{"application/x-www-form-urlencoded"},
+		"Content-Type": {"application/x-www-form-urlencoded"},
 	})
 
 	tests := []struct {
@@ -460,7 +474,7 @@ func TestCreateInOrderAction(t *testing.T) {
 			act: createInOrderAction{
 				Dir: "/foo/",
 			},
-			wantURL:  "http://example.com/foo",
+			wantURL:  "http://example.com/foo/",
 			wantBody: "value=",
 		},
 
@@ -499,7 +513,7 @@ func TestCreateInOrderAction(t *testing.T) {
 
 func TestDeleteAction(t *testing.T) {
 	wantHeader := http.Header(map[string][]string{
-		"Content-Type": []string{"application/x-www-form-urlencoded"},
+		"Content-Type": {"application/x-www-form-urlencoded"},
 	})
 
 	tests := []struct {
@@ -555,7 +569,7 @@ func TestDeleteAction(t *testing.T) {
 			act: deleteAction{
 				Key: "/foo/",
 			},
-			wantURL: "http://example.com/foo",
+			wantURL: "http://example.com/foo/",
 		},
 
 		// Recursive set to true
@@ -1199,7 +1213,7 @@ func TestHTTPKeysAPIGetResponse(t *testing.T) {
 		Node: &Node{
 			Key: "/pants/foo/bar",
 			Nodes: []*Node{
-				&Node{Key: "/pants/foo/bar/baz", Value: "snarf", CreatedIndex: 21, ModifiedIndex: 25},
+				{Key: "/pants/foo/bar/baz", Value: "snarf", CreatedIndex: 21, ModifiedIndex: 25},
 			},
 			CreatedIndex:  uint64(19),
 			ModifiedIndex: uint64(25),

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/members_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/members_test.go
@@ -47,8 +47,8 @@ func TestMembersAPIActionAdd(t *testing.T) {
 	ep := url.URL{Scheme: "http", Host: "example.com"}
 	act := &membersAPIActionAdd{
 		peerURLs: types.URLs([]url.URL{
-			url.URL{Scheme: "https", Host: "127.0.0.1:8081"},
-			url.URL{Scheme: "http", Host: "127.0.0.1:8080"},
+			{Scheme: "https", Host: "127.0.0.1:8081"},
+			{Scheme: "http", Host: "127.0.0.1:8080"},
 		}),
 	}
 
@@ -74,8 +74,8 @@ func TestMembersAPIActionUpdate(t *testing.T) {
 	act := &membersAPIActionUpdate{
 		memberID: "0xabcd",
 		peerURLs: types.URLs([]url.URL{
-			url.URL{Scheme: "https", Host: "127.0.0.1:8081"},
-			url.URL{Scheme: "http", Host: "127.0.0.1:8080"},
+			{Scheme: "https", Host: "127.0.0.1:8081"},
+			{Scheme: "http", Host: "127.0.0.1:8080"},
 		}),
 	}
 
@@ -288,8 +288,8 @@ func TestMemberCollectionUnmarshal(t *testing.T) {
 func TestMemberCreateRequestMarshal(t *testing.T) {
 	req := memberCreateOrUpdateRequest{
 		PeerURLs: types.URLs([]url.URL{
-			url.URL{Scheme: "http", Host: "127.0.0.1:8081"},
-			url.URL{Scheme: "https", Host: "127.0.0.1:8080"},
+			{Scheme: "http", Host: "127.0.0.1:8081"},
+			{Scheme: "https", Host: "127.0.0.1:8080"},
 		}),
 	}
 	want := []byte(`{"peerURLs":["http://127.0.0.1:8081","https://127.0.0.1:8080"]}`)
@@ -307,7 +307,7 @@ func TestMemberCreateRequestMarshal(t *testing.T) {
 func TestHTTPMembersAPIAddSuccess(t *testing.T) {
 	wantAction := &membersAPIActionAdd{
 		peerURLs: types.URLs([]url.URL{
-			url.URL{Scheme: "http", Host: "127.0.0.1:7002"},
+			{Scheme: "http", Host: "127.0.0.1:7002"},
 		}),
 	}
 
@@ -472,7 +472,7 @@ func TestHTTPMembersAPIListSuccess(t *testing.T) {
 	}
 
 	wantResponseMembers := []Member{
-		Member{
+		{
 			ID:         "94088180e21eb87b",
 			Name:       "node2",
 			PeerURLs:   []string{"http://127.0.0.1:7002"},

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/srv_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/srv_test.go
@@ -36,40 +36,40 @@ func TestSRVDiscover(t *testing.T) {
 		},
 		{
 			[]*net.SRV{
-				&net.SRV{Target: "10.0.0.1", Port: 2480},
-				&net.SRV{Target: "10.0.0.2", Port: 2480},
-				&net.SRV{Target: "10.0.0.3", Port: 2480},
+				{Target: "10.0.0.1", Port: 2480},
+				{Target: "10.0.0.2", Port: 2480},
+				{Target: "10.0.0.3", Port: 2480},
 			},
 			[]*net.SRV{},
 			[]string{"https://10.0.0.1:2480", "https://10.0.0.2:2480", "https://10.0.0.3:2480"},
 		},
 		{
 			[]*net.SRV{
-				&net.SRV{Target: "10.0.0.1", Port: 2480},
-				&net.SRV{Target: "10.0.0.2", Port: 2480},
-				&net.SRV{Target: "10.0.0.3", Port: 2480},
+				{Target: "10.0.0.1", Port: 2480},
+				{Target: "10.0.0.2", Port: 2480},
+				{Target: "10.0.0.3", Port: 2480},
 			},
 			[]*net.SRV{
-				&net.SRV{Target: "10.0.0.1", Port: 7001},
-			},
-			[]string{"https://10.0.0.1:2480", "https://10.0.0.2:2480", "https://10.0.0.3:2480", "http://10.0.0.1:7001"},
-		},
-		{
-			[]*net.SRV{
-				&net.SRV{Target: "10.0.0.1", Port: 2480},
-				&net.SRV{Target: "10.0.0.2", Port: 2480},
-				&net.SRV{Target: "10.0.0.3", Port: 2480},
-			},
-			[]*net.SRV{
-				&net.SRV{Target: "10.0.0.1", Port: 7001},
+				{Target: "10.0.0.1", Port: 7001},
 			},
 			[]string{"https://10.0.0.1:2480", "https://10.0.0.2:2480", "https://10.0.0.3:2480", "http://10.0.0.1:7001"},
 		},
 		{
 			[]*net.SRV{
-				&net.SRV{Target: "a.example.com", Port: 2480},
-				&net.SRV{Target: "b.example.com", Port: 2480},
-				&net.SRV{Target: "c.example.com", Port: 2480},
+				{Target: "10.0.0.1", Port: 2480},
+				{Target: "10.0.0.2", Port: 2480},
+				{Target: "10.0.0.3", Port: 2480},
+			},
+			[]*net.SRV{
+				{Target: "10.0.0.1", Port: 7001},
+			},
+			[]string{"https://10.0.0.1:2480", "https://10.0.0.2:2480", "https://10.0.0.3:2480", "http://10.0.0.1:7001"},
+		},
+		{
+			[]*net.SRV{
+				{Target: "a.example.com", Port: 2480},
+				{Target: "b.example.com", Port: 2480},
+				{Target: "c.example.com", Port: 2480},
 			},
 			[]*net.SRV{},
 			[]string{"https://a.example.com:2480", "https://b.example.com:2480", "https://c.example.com:2480"},

--- a/Godeps/_workspace/src/github.com/coreos/etcd/pkg/pathutil/path.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/pkg/pathutil/path.go
@@ -1,0 +1,29 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pathutil
+
+import "path"
+
+// CanonicalURLPath returns the canonical url path for p, which follows the rules:
+// 1. the path always starts with "/"
+// 2. replace multiple slashes with a single slash
+// 3. replace each '.' '..' path name element with equivalent one
+// 4. keep the trailing slash
+// The function is borrowed from stdlib http.cleanPath in server.go.
+func CanonicalURLPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	np := path.Clean(p)
+	// path.Clean removes trailing slash except for root,
+	// put the trailing slash back if necessary.
+	if p[len(p)-1] == '/' && np != "/" {
+		np += "/"
+	}
+	return np
+}

--- a/Godeps/_workspace/src/github.com/coreos/etcd/pkg/pathutil/path_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/pkg/pathutil/path_test.go
@@ -1,0 +1,38 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathutil
+
+import "testing"
+
+func TestCanonicalURLPath(t *testing.T) {
+	tests := []struct {
+		p  string
+		wp string
+	}{
+		{"/a", "/a"},
+		{"", "/"},
+		{"a", "/a"},
+		{"//a", "/a"},
+		{"/a/.", "/a"},
+		{"/a/..", "/"},
+		{"/a/", "/a/"},
+		{"/a//", "/a/"},
+	}
+	for i, tt := range tests {
+		if g := CanonicalURLPath(tt.p); g != tt.wp {
+			t.Errorf("#%d: canonical path = %s, want %s", i, g, tt.wp)
+		}
+	}
+}

--- a/subnet/etcd.go
+++ b/subnet/etcd.go
@@ -462,9 +462,12 @@ func (m *EtcdManager) getNetworks(ctx context.Context) ([]string, uint64, error)
 
 	if err == nil {
 		for _, node := range resp.Node.Nodes {
-			netname, err := m.parseNetworkKey(node.Key)
-			if err == nil {
-				networks = append(networks, netname)
+			// Look for '/config' on the child nodes
+			for _, child := range node.Nodes {
+				netname, err := m.parseNetworkKey(child.Key)
+				if err == nil {
+					networks = append(networks, netname)
+				}
 			}
 		}
 


### PR DESCRIPTION
The first patch fixes up my previous network watching stuff, where the testcases didn't quite match actual etcd behavior and thus the code was also slightly wrong.

The second patch I have questions on... When the etcd client got switched to etcd/client, it broke cancel handling. Because etcd/client returns ClusterError objects from its HTTP methods, those get passed down to registry.go and etcd.go, and then stuff like:

    case err == context.Canceled, err == context.DeadlineExceeded:

doesn't work because 'err' is a ClusterError, not a context error. How should this get fixed? I had a couple approaches:

1) strip ClusterErrors in registry.go and return only the first internal error; but this doesn't work because etcd.go checks for etcd.Error too.

2) strip ClusterErrors in etcd.go and return only the first internal error; but this doesn't quite work either because callers are looking for only one error, and ClusterError can hold multiple errors

3) create some kind of MatchError() function that knows about ClusterError and etcd.Error internals and does the right thing; this is kinda ugly because it leaks ClusterError semantics out to stuff that shouldn't know about etcd at all (like when the backends check for cancelation of AcquireLease()). I guess this function should go into the subnet.Manager interface and we mandate that all callers of subnet.Manager use it for error checking? This is what I ended up implementing.

Thoughts? The orignal problem I had was that at Ctrl^C/exit time, flannel never exited because watch.go::WatchLeases() never sees the cancel because it's checking for context.Canceled, not ClusterError.Errors[0] == context.Canceled.