### PR TITLE
[Hack] Replace troublesome glog references with log

### DIFF
--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -36,11 +36,11 @@ const (
 )
 
 type VXLANBackend struct {
-	sm       subnet.Manager
-	network  string
-	cfg      struct {
-		 VNI  int
-		 Port int
+	sm      subnet.Manager
+	network string
+	cfg     struct {
+		VNI  int
+		Port int
 	}
 	extIndex int
 	extIaddr net.IP

--- a/subnet/registry.go
+++ b/subnet/registry.go
@@ -16,13 +16,13 @@ package subnet
 
 import (
 	"fmt"
+	"log"
 	"path"
 	"sync"
 	"time"
 
 	etcd "github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/etcd/client"
 	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/etcd/pkg/transport"
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
 	"github.com/coreos/flannel/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
@@ -166,7 +166,7 @@ func (esr *etcdSubnetRegistry) resetClient() {
 func ensureExpiration(resp *etcd.Response, ttl time.Duration) {
 	if resp.Node.Expiration == nil {
 		// should not be but calc it ourselves in this case
-		log.Info("Expiration field missing on etcd response, calculating locally")
+		log.Printf("Expiration field missing on etcd response, calculating locally")
 		exp := time.Now().Add(time.Duration(ttl) * time.Second)
 		resp.Node.Expiration = &exp
 	}

--- a/subnet/renew.go
+++ b/subnet/renew.go
@@ -17,8 +17,8 @@ package subnet
 import (
 	"time"
 
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
 	"github.com/coreos/flannel/Godeps/_workspace/src/golang.org/x/net/context"
+	"log"
 )
 
 const (
@@ -33,12 +33,12 @@ func LeaseRenewer(ctx context.Context, m Manager, network string, lease *Lease) 
 		case <-time.After(dur):
 			err := m.RenewLease(ctx, network, lease)
 			if err != nil {
-				log.Error("Error renewing lease (trying again in 1 min): ", err)
+				log.Printf("Error renewing lease (trying again in 1 min): ", err)
 				dur = time.Minute
 				continue
 			}
 
-			log.Info("Lease renewed, new expiration: ", lease.Expiration)
+			log.Printf("Lease renewed, new expiration: ", lease.Expiration)
 			dur = lease.Expiration.Sub(time.Now()) - renewMargin
 
 		case <-ctx.Done():

--- a/subnet/watch.go
+++ b/subnet/watch.go
@@ -17,8 +17,8 @@ package subnet
 import (
 	"time"
 
-	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
 	"github.com/coreos/flannel/Godeps/_workspace/src/golang.org/x/net/context"
+	"log"
 )
 
 // WatchLeases performs a long term watch of the given network's subnet leases
@@ -38,7 +38,7 @@ func WatchLeases(ctx context.Context, sm Manager, network string, ownLease *Leas
 				return
 			}
 
-			log.Errorf("Watch subnets: %v", err)
+			log.Printf("Watch subnets: %v", err)
 			time.Sleep(time.Second)
 			continue
 		}
@@ -136,7 +136,7 @@ func (lw *leaseWatcher) remove(lease *Lease) Event {
 		}
 	}
 
-	log.Errorf("Removed subnet (%s) was not found", lease.Subnet)
+	log.Printf("Removed subnet (%s) was not found", lease.Subnet)
 	return Event{EventRemoved, *lease, ""}
 }
 
@@ -160,7 +160,7 @@ func WatchNetworks(ctx context.Context, sm Manager, receiver chan []Event) {
 				return
 			}
 
-			log.Errorf("Watch networks: %v", err)
+			log.Printf("Watch networks: %v", err)
 			time.Sleep(time.Second)
 			continue
 		}
@@ -240,7 +240,7 @@ func (nw *netWatcher) remove(network string) Event {
 	if _, ok := nw.networks[network]; ok {
 		delete(nw.networks, network)
 	} else {
-		log.Errorf("Removed network (%s) was not found", network)
+		log.Printf("Removed network (%s) was not found", network)
 	}
 
 	return Event{EventRemoved, Lease{}, network}


### PR DESCRIPTION
Flannel's glog import strategy leads to a double initialization of glog flags when imported from another package that also uses glog. Most (all?) coreos packages use log. I've just replaced the instances I need to use flannel within kubernetes, open to non-hacky suggestions. 