### PR TITLE
Better handling of Ctrl+C

### DIFF
--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -36,11 +36,11 @@ const (
 )
 
 type VXLANBackend struct {
-	sm       subnet.Manager
-	network  string
-	cfg      struct {
-		 VNI  int
-		 Port int
+	sm      subnet.Manager
+	network string
+	cfg     struct {
+		VNI  int
+		Port int
 	}
 	extIndex int
 	extIaddr net.IP
@@ -94,17 +94,9 @@ func (vb *VXLANBackend) RegisterNetwork(ctx context.Context, network string, con
 	}
 
 	var err error
-	for {
-		vb.dev, err = newVXLANDevice(&devAttrs)
-		if err == nil {
-			break
-		} else {
-			log.Error("VXLAN init: ", err)
-			log.Info("Retrying in 1 second...")
-
-			// wait 1 sec before retrying
-			time.Sleep(1 * time.Second)
-		}
+	vb.dev, err = newVXLANDevice(&devAttrs)
+	if err != nil {
+		return nil, err
 	}
 
 	sa, err := newSubnetAttrs(vb.extEaddr, vb.dev.MACAddr())

--- a/network/network.go
+++ b/network/network.go
@@ -94,16 +94,16 @@ func (n *Network) Init(iface *net.Interface, iaddr net.IP, eaddr net.IP) *backen
 	}
 
 	for _, s := range steps {
-		for ; ; time.Sleep(time.Second) {
-			select {
-			case <-n.ctx.Done():
-				return nil
-			default:
+		for {
+			if err := s(); err == nil {
+				break
 			}
 
-			err := s()
-			if err == nil {
-				break
+			select {
+			case <-time.After(time.Second):
+
+			case <-n.ctx.Done():
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
VXLAN should fail RegisterNetwork call as
outer code does the retrying. This causes
SIGINT to be properly processed.