### PR TITLE
Notify systemd service when server is ready to listen

### DIFF
--- a/remote/server.go
+++ b/remote/server.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/go-systemd/activation"
+	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/coreos/go-systemd/daemon"
 	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
 	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/coreos/flannel/Godeps/_workspace/src/golang.org/x/net/context"
@@ -275,6 +276,8 @@ func RunServer(ctx context.Context, sm subnet.Manager, listenAddr, cafile, certf
 	go func() {
 		c <- http.Serve(l, httpLogger(r))
 	}()
+
+	daemon.SdNotify("READY=1")
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
When running flannel with -listen option, systemd service is not notified and 'systemctl start flannel' does not return. Adding daemon.SdNotify("READY=1") to RunServer notifies systemd and the command returns.

The correct place for notifying the systemd is line 278 of remote/server.go [1]. It is the line where a listener is created and the execution is just before the server can start listening for incoming requests.

[1] https://github.com/coreos/flannel/blob/master/remote/server.go#L278