### PR TITLE
build: use `git describe` output in version

### DIFF
--- a/build
+++ b/build
@@ -2,6 +2,8 @@
 
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/flannel"
+VERSION=$(git describe --dirty)
+GLDFLAGS="-X github.com/coreos/flannel/version.Version \"${VERSION}\""
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}
@@ -15,7 +17,7 @@ eval $(go env)
 
 if [ ${GOOS} = "linux" ]; then
 	echo "Building flanneld..."
-	go build -o ${GOBIN}/flanneld ${REPO_PATH}
+	go build -o ${GOBIN}/flanneld -ldflags "${GLDFLAGS}" ${REPO_PATH}
 else
 	echo "Not on Linux - skipping flanneld build"
 fi

--- a/dist/bump-release.sh
+++ b/dist/bump-release.sh
@@ -13,8 +13,8 @@ VERSIONTAG="v${VERSION}"
 TAGBR="v${VERSION}-tag"
 
 replace_version() {
-	sed -i -e "s/const Version.*/const Version = \"$1\"/" ../version.go
-	git commit -m "version: bump to v$1" ../version.go
+	sed -i -e "s/const Version.*/const Version = \"$1\"/" version/version.go
+	git commit -m "version: bump to v$1" version/version.go
 }
 
 # make sure we're up to date
@@ -24,8 +24,8 @@ git pull --ff-only ${ORIGIN} master
 replace_version ${VERSION}
 git tag -a -m "${VERSIONTAG}" "${VERSIONTAG}"
 
-# bump ver to +git and push to origin
-replace_version "${VERSION}+git"
+# bump ver to placeholder and push to origin
+replace_version "${VERSION}+was-not-built-properly"
 git push "${ORIGIN}" master
 
 # push the tag

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/coreos/flannel/network"
 	"github.com/coreos/flannel/remote"
 	"github.com/coreos/flannel/subnet"
+	"github.com/coreos/flannel/version"
 
 	// Backends need to be imported for their init() to get executed and them to register
 	_ "github.com/coreos/flannel/backend/alloc"
@@ -103,7 +104,7 @@ func main() {
 	}
 
 	if opts.version {
-		fmt.Fprintln(os.Stderr, Version)
+		fmt.Fprintln(os.Stderr, version.Version)
 		os.Exit(0)
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package version
 
-const Version = "0.5.3+git"
+var Version = "0.5.3+was-not-built-properly"


### PR DESCRIPTION
This is much more helpful for debugging when flanneld is built from
master.