### PR TITLE
Allow network leases to be nil and networks to contribute to subnet file

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -50,6 +50,7 @@ type Network interface {
 	Lease() *subnet.Lease
 	MTU() int
 	Run(ctx context.Context)
+	SubnetFileVars() map[string]string
 }
 
 type BackendCtor func(sm subnet.Manager, ei *ExternalInterface) (Backend, error)
@@ -69,4 +70,8 @@ func (n *SimpleNetwork) MTU() int {
 
 func (_ *SimpleNetwork) Run(ctx context.Context) {
 	<-ctx.Done()
+}
+
+func (_ *SimpleNetwork) SubnetFileVars() map[string]string {
+	return nil
 }

--- a/backend/hostgw/network.go
+++ b/backend/hostgw/network.go
@@ -45,6 +45,10 @@ func (n *network) MTU() int {
 	return n.extIface.Iface.MTU
 }
 
+func (n *network) SubnetFileVars() map[string]string {
+	return nil
+}
+
 func (n *network) Run(ctx context.Context) {
 	wg := sync.WaitGroup{}
 


### PR DESCRIPTION
For the OpenShift OVS stuff we have an IPAM model where each node grabs a subnet lease, rather than each tenant network having its own subnet.  Mutli-tenancy is enforced with the OpenFlow rules.

The approach I took for the plugin is one well-known "cluster network" which every node running flannel grabs a lease in.  Tenant networks never have leases (since pod IPs are allocated out of the common node subnet), but they do have other data that we'd like to write to subnet files (like the VNID, or Virtual Network ID).  See https://github.com/dcbw/flannel/tree/ovs for details.