### PR TITLE
Add reservations to admin control subnet allocs

### DIFF
--- a/subnet/mock_registry.go
+++ b/subnet/mock_registry.go
@@ -140,7 +140,10 @@ func (msr *MockSubnetRegistry) createSubnet(ctx context.Context, network string,
 
 	msr.index += 1
 
-	exp := clock.Now().Add(ttl)
+	exp := time.Time{}
+	if ttl != 0 {
+		exp = clock.Now().Add(ttl)
+	}
 
 	l := Lease{
 		Subnet:     sn,
@@ -169,7 +172,10 @@ func (msr *MockSubnetRegistry) updateSubnet(ctx context.Context, network string,
 
 	msr.index += 1
 
-	exp := clock.Now().Add(ttl)
+	exp := time.Time{}
+	if ttl != 0 {
+		exp = clock.Now().Add(ttl)
+	}
 
 	sub, i, err := n.findSubnet(sn)
 	if err != nil {

--- a/subnet/subnet.go
+++ b/subnet/subnet.go
@@ -26,6 +26,11 @@ import (
 	"github.com/coreos/flannel/pkg/ip"
 )
 
+var (
+	ErrLeaseTaken  = errors.New("subnet: lease already taken")
+	ErrNoMoreTries = errors.New("subnet: no more tries")
+)
+
 type LeaseAttrs struct {
 	PublicIP    ip.IP4
 	BackendType string          `json:",omitempty"`
@@ -42,6 +47,11 @@ type Lease struct {
 
 func (l *Lease) Key() string {
 	return MakeSubnetKey(l.Subnet)
+}
+
+type Reservation struct {
+	Subnet   ip.IP4Net
+	PublicIP ip.IP4
 }
 
 type (
@@ -129,4 +139,8 @@ type Manager interface {
 	WatchLease(ctx context.Context, network string, sn ip.IP4Net, cursor interface{}) (LeaseWatchResult, error)
 	WatchLeases(ctx context.Context, network string, cursor interface{}) (LeaseWatchResult, error)
 	WatchNetworks(ctx context.Context, cursor interface{}) (NetworkWatchResult, error)
+
+	AddReservation(ctx context.Context, network string, r *Reservation) error
+	RemoveReservation(ctx context.Context, network string, subnet ip.IP4Net) error
+	ListReservations(ctx context.Context, network string) ([]Reservation, error)
 }


### PR DESCRIPTION
This adds ability to add and remove reservations
for subnet allocations. A subnet is reserved with
the host IP (PublicIP). flannel will then use this
subnet for a host requesting a subnet.

Reservations are denoted in etcd as subnets with no
expiration (TTL is zero). When a reserved subnet is
allocated, it's TTL continues to be not set. If a
reservation is removed, the TTL is set to the usual
24 hours.

Also adds corresponding client/server APIs for
reservation management.

Fixes #280