### PR TITLE
subnet: fix SubnetMax calculation when parsing config

### DIFF
--- a/subnet/config.go
+++ b/subnet/config.go
@@ -80,7 +80,7 @@ func ParseConfig(s string) (*Config, error) {
 	}
 
 	if cfg.SubnetMax == ip.IP4(0) {
-		cfg.SubnetMax = cfg.Network.Next().IP - subnetSize
+		cfg.SubnetMax = cfg.SubnetMin + subnetSize
 	} else if !cfg.Network.Contains(cfg.SubnetMax) {
 		return nil, errors.New("SubnetMax is not in the range of the Network")
 	}

--- a/subnet/config_test.go
+++ b/subnet/config_test.go
@@ -35,8 +35,8 @@ func TestConfigDefaults(t *testing.T) {
 		t.Errorf("SubnetMin mismatch, expected 10.3.1.0, got %s", cfg.SubnetMin)
 	}
 
-	if cfg.SubnetMax.String() != "10.3.255.0" {
-		t.Errorf("SubnetMax mismatch, expected 10.3.255.0, got %s", cfg.SubnetMax)
+	if cfg.SubnetMax.String() != "10.3.2.0" {
+		t.Errorf("SubnetMax mismatch, expected 10.3.2.0, got %s", cfg.SubnetMax)
 	}
 
 	if cfg.SubnetLen != 24 {


### PR DESCRIPTION
Given a /24 subnet I see:
"Picking subnet in range 10.244.8.128 ... 10.244.8.128"
"Failed to acquire subnet: out of subnets"
The SubnetMax calculation looks wrong, fixed it.

I could not add or run tests, because I'm on a Mac, and
am hitting: https://github.com/vishvananda/netlink/issues/17