### PR TITLE
Add Open vSwitch-based multitenant backend for use with OpenShift / Kubernetes

### DIFF
--- a/backend/ovs/device.go
+++ b/backend/ovs/device.go
@@ -1,0 +1,661 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovs
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
+	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink"
+	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+
+	"github.com/coreos/flannel/pkg/ip"
+)
+
+type ovsDevice struct {
+	bridgeName      string
+	oflowProto      string
+	opHandler       OpHandler
+	clusterNetwork  ip.IP4Net
+	nodeNetwork     ip.IP4Net
+	servicesNetwork ip.IP4Net
+	gwAddr          net.IP
+}
+
+func newOVSDevice() (*ovsDevice, error) {
+	return newOVSDeviceWithHandler(&liveOpHandler{})
+}
+
+func newOVSDeviceWithHandler(handler OpHandler) (*ovsDevice, error) {
+	bridge := &ovsDevice{
+		bridgeName: "br0",
+		oflowProto: "OpenFlow13",
+		opHandler:  handler,
+	}
+	err := bridge.genericSetup()
+	return bridge, err
+}
+
+//*****************************************************************************
+
+type OpHandler interface {
+	OvsExec(cmd string, args ...string) ([]byte, error)
+	Modprobe(module string) ([]byte, error)
+	LinkAdd(link netlink.Link) error
+	LinkDel(link netlink.Link) error
+	LinkByIndex(index int) (netlink.Link, error)
+	LinkByName(name string) (netlink.Link, error)
+	LinkSetUp(link netlink.Link) error
+	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
+	AddrAdd(link netlink.Link, addr *netlink.Addr) error
+	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
+	RouteAdd(route *netlink.Route) error
+	RouteDel(route *netlink.Route) error
+	RouteDelWithProtocol(route *netlink.Route, protocol uint8) error
+	Sysctl(item, value string) error
+}
+
+type liveOpHandler struct{}
+
+func (h *liveOpHandler) OvsExec(cmd string, args ...string) ([]byte, error) {
+	return exec.Command(cmd, args...).CombinedOutput()
+}
+
+func (h *liveOpHandler) Modprobe(module string) ([]byte, error) {
+	return exec.Command("modprobe", module).CombinedOutput()
+}
+
+func (h *liveOpHandler) LinkAdd(link netlink.Link) error {
+	return netlink.LinkAdd(link)
+}
+
+func (h *liveOpHandler) LinkDel(link netlink.Link) error {
+	return netlink.LinkDel(link)
+}
+
+func (h *liveOpHandler) LinkByName(name string) (netlink.Link, error) {
+	return netlink.LinkByName(name)
+}
+
+func (h *liveOpHandler) LinkByIndex(index int) (netlink.Link, error) {
+	return netlink.LinkByIndex(index)
+}
+
+func (h *liveOpHandler) LinkSetUp(link netlink.Link) error {
+	return netlink.LinkSetUp(link)
+}
+
+func (h *liveOpHandler) LinkSetMaster(link netlink.Link, master *netlink.Bridge) error {
+	return netlink.LinkSetMaster(link, master)
+}
+
+func (h *liveOpHandler) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
+	return netlink.AddrAdd(link, addr)
+}
+
+func (h *liveOpHandler) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	return netlink.AddrList(link, family)
+}
+
+func (h *liveOpHandler) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
+	return netlink.RouteList(link, family)
+}
+
+func (h *liveOpHandler) RouteAdd(route *netlink.Route) error {
+	return netlink.RouteAdd(route)
+}
+
+func (h *liveOpHandler) RouteDel(route *netlink.Route) error {
+	return netlink.RouteDel(route)
+}
+
+func (h *liveOpHandler) RouteDelWithProtocol(route *netlink.Route, protocol uint8) error {
+	if (route.Dst == nil || route.Dst.IP == nil) && route.Src == nil && route.Gw == nil {
+		return fmt.Errorf("one of Dst.IP, Src, or Gw must not be nil")
+	}
+
+	req := nl.NewNetlinkRequest(syscall.RTM_DELROUTE, syscall.NLM_F_ACK)
+
+	msg := nl.NewRtMsg()
+	// vishvananda/netlink hardcodes Protocol to RTPROT_BOOT; override that
+	msg.Protocol = syscall.RTPROT_UNSPEC
+	msg.Scope = uint8(route.Scope)
+	family := -1
+	var rtAttrs []*nl.RtAttr
+
+	if route.Dst != nil && route.Dst.IP != nil {
+		dstLen, _ := route.Dst.Mask.Size()
+		msg.Dst_len = uint8(dstLen)
+		dstFamily := nl.GetIPFamily(route.Dst.IP)
+		family = dstFamily
+		var dstData []byte
+		if dstFamily == netlink.FAMILY_V4 {
+			dstData = route.Dst.IP.To4()
+		} else {
+			dstData = route.Dst.IP.To16()
+		}
+		rtAttrs = append(rtAttrs, nl.NewRtAttr(syscall.RTA_DST, dstData))
+	}
+
+	if route.Src != nil {
+		srcFamily := nl.GetIPFamily(route.Src)
+		if family != -1 && family != srcFamily {
+			return fmt.Errorf("source and destination ip are not the same IP family")
+		}
+		family = srcFamily
+		var srcData []byte
+		if srcFamily == netlink.FAMILY_V4 {
+			srcData = route.Src.To4()
+		} else {
+			srcData = route.Src.To16()
+		}
+		// The commonly used src ip for routes is actually PREFSRC
+		rtAttrs = append(rtAttrs, nl.NewRtAttr(syscall.RTA_PREFSRC, srcData))
+	}
+
+	if route.Gw != nil {
+		gwFamily := nl.GetIPFamily(route.Gw)
+		if family != -1 && family != gwFamily {
+			return fmt.Errorf("gateway, source, and destination ip are not the same IP family")
+		}
+		family = gwFamily
+		var gwData []byte
+		if gwFamily == netlink.FAMILY_V4 {
+			gwData = route.Gw.To4()
+		} else {
+			gwData = route.Gw.To16()
+		}
+		rtAttrs = append(rtAttrs, nl.NewRtAttr(syscall.RTA_GATEWAY, gwData))
+	}
+
+	msg.Family = uint8(family)
+
+	req.AddData(msg)
+	for _, attr := range rtAttrs {
+		req.AddData(attr)
+	}
+
+	var (
+		b      = make([]byte, 4)
+		native = nl.NativeEndian()
+	)
+	native.PutUint32(b, uint32(route.LinkIndex))
+
+	req.AddData(nl.NewRtAttr(syscall.RTA_OIF, b))
+
+	_, err := req.Execute(syscall.NETLINK_ROUTE, 0)
+	return err
+}
+
+func (h *liveOpHandler) Sysctl(item, value string) error {
+	o, err := exec.Command("sysctl", "-w", fmt.Sprintf("%s=%s", item, value)).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("sysctl %s=%s failed: %s (%o)", item, value, err, o)
+	}
+	return nil
+}
+
+//*****************************************************************************
+
+func (dev *ovsDevice) vsCtl(cmd string, args ...string) error {
+	allArgs := make([]string, 0, 1+len(args))
+	allArgs = append(allArgs, cmd)
+	for _, a := range args {
+		allArgs = append(allArgs, a)
+	}
+	_, err := dev.opHandler.OvsExec("ovs-vsctl", allArgs...)
+	return err
+}
+
+func (dev *ovsDevice) ofCtl(cmd, theRest string) ([]byte, error) {
+	return dev.opHandler.OvsExec("ovs-ofctl", "-O", dev.oflowProto, cmd, dev.bridgeName, theRest)
+}
+
+func (dev *ovsDevice) addFlow(flow string, args ...interface{}) error {
+	if len(args) > 0 {
+		flow = fmt.Sprintf(flow, args...)
+	}
+	log.Infof("OVS ADD FLOW: %s", flow)
+	out, err := dev.ofCtl("add-flow", flow)
+	if err != nil {
+		log.Errorf("Error adding OVS flow %s: %s (%v)", flow, out, err)
+		return err
+	}
+	return nil
+}
+
+func (dev *ovsDevice) delFlows(flow string, args ...interface{}) error {
+	if len(args) > 0 {
+		flow = fmt.Sprintf(flow, args...)
+	}
+	out, err := dev.ofCtl("del-flows", flow)
+	log.Infof("Output of deleting network %s flows: %s (%v)", flow, out, err)
+	return err
+}
+
+func (dev *ovsDevice) getPortNumber(portName string) (uint, error) {
+	out, err := dev.ofCtl("dump-ports", portName)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "port") {
+			continue
+		}
+		colon := strings.Index(line, ":")
+		if colon < 0 {
+			continue
+		}
+		u, err := strconv.ParseUint(strings.TrimSpace(line[4:colon]), 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		return uint(u), nil
+	}
+	return 0, fmt.Errorf("Failed to find OVS port number for %s", portName)
+}
+
+//*****************************************************************************
+
+func (dev *ovsDevice) addGatewayAddressToLink(linkName string) (netlink.Link, error) {
+	link, err := dev.opHandler.LinkByName(linkName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s: %v", linkName, err)
+	}
+	addrStr := fmt.Sprintf("%s/%d", dev.gwAddr.String(), dev.nodeNetwork.PrefixLen)
+	addr, err := netlink.ParseAddr(addrStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse gateway address %s: %v", addrStr, err)
+	}
+	if err := dev.opHandler.AddrAdd(link, addr); err != nil {
+		return nil, fmt.Errorf("failed to add gateway address %s to %s: %v", linkName, addrStr, err)
+	}
+	if err := dev.opHandler.LinkSetUp(link); err != nil {
+		return nil, fmt.Errorf("failed to bring up %s: %v", linkName, err)
+	}
+
+	return link, nil
+}
+
+func (dev *ovsDevice) matchRoute(m syscall.NetlinkMessage, route *netlink.Route) bool {
+	if m.Header.Type != syscall.RTM_NEWROUTE {
+		return false
+	}
+
+	msg := nl.DeserializeRtMsg(m.Data)
+
+	if msg.Flags&syscall.RTM_F_CLONED != 0 {
+		return false
+	}
+	if msg.Table != syscall.RT_TABLE_LOCAL && msg.Table != syscall.RT_TABLE_MAIN {
+		return false
+	}
+	if msg.Scope != uint8(route.Scope) {
+		return false
+	}
+
+	attrs, err := nl.ParseRouteAttr(m.Data[msg.Len():])
+	if err != nil {
+		return false
+	}
+
+	var gotGw, gotSrc, gotDst, gotIfindex bool
+	native := nl.NativeEndian()
+	for _, attr := range attrs {
+		switch attr.Attr.Type {
+		case syscall.RTA_GATEWAY:
+			// not always present
+			if !net.IP(attr.Value).Equal(route.Gw) {
+				return false
+			}
+			gotGw = true
+		case syscall.RTA_PREFSRC:
+			if !net.IP(attr.Value).Equal(route.Src) {
+				return false
+			}
+			gotSrc = true
+		case syscall.RTA_DST:
+			dst := &net.IPNet{
+				IP:   attr.Value,
+				Mask: net.CIDRMask(int(msg.Dst_len), 8*len(attr.Value)),
+			}
+			if !dst.IP.Equal(route.Dst.IP) {
+				return false
+			}
+			if !bytes.Equal(dst.Mask, route.Dst.Mask) {
+				return false
+			}
+			gotDst = true
+		case syscall.RTA_OIF:
+			routeIndex := int(native.Uint32(attr.Value[0:4]))
+			if routeIndex != route.LinkIndex {
+				return false
+			}
+			gotIfindex = true
+		}
+	}
+
+	// RTA_GATEWAY not always present if empty
+	if route.Gw != nil && !gotGw {
+		return false
+	}
+
+	return gotSrc && gotDst && gotIfindex
+}
+
+func (dev *ovsDevice) removeLbrSubnetRoute(nlsock *nl.NetlinkSocket, ifindex int) {
+	// Remove the kernel-added subnet route for lbr0
+	route := netlink.Route{
+		Scope:     netlink.SCOPE_LINK,
+		Dst:       dev.nodeNetwork.ToIPNet(),
+		Src:       dev.gwAddr,
+		LinkIndex: ifindex,
+	}
+	if err := dev.opHandler.RouteDelWithProtocol(&route, syscall.RTPROT_UNSPEC); err != nil && err != syscall.ENOENT {
+		log.Errorf("Failed to remove route initial: %v ", err)
+	}
+
+	for {
+		msgs, err := nlsock.Receive()
+		if err != nil {
+			log.Errorf("Failed to receive from netlink: %v ", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		for _, msg := range msgs {
+			if dev.matchRoute(msg, &route) {
+				dev.opHandler.RouteDelWithProtocol(&route, syscall.RTPROT_UNSPEC)
+				break
+			}
+		}
+	}
+}
+
+func (dev *ovsDevice) ensureDockerBridge() error {
+	// Remove any existing lbr0
+	lbr0, err := dev.opHandler.LinkByName("lbr0")
+	if err == nil {
+		dev.opHandler.LinkDel(lbr0)
+	}
+
+	// Add lbr0 with clean config
+	lbr0 = &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: "lbr0",
+		},
+	}
+	if err := dev.opHandler.LinkAdd(lbr0); err != nil {
+		return fmt.Errorf("failed to add lbr0: %v", err)
+	}
+
+	// Remove the kernel-added subnet route for lbr0
+	// Watch for it and delete it if it shows up later
+	nlsock, err := nl.Subscribe(syscall.NETLINK_ROUTE, syscall.RTNLGRP_IPV4_ROUTE)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to netlink RTNLGRP_IPV4_ROUTE messages: %v", err)
+	}
+
+	go dev.removeLbrSubnetRoute(nlsock, lbr0.Attrs().Index)
+
+	// Add the gateway address to it (for docker IPAM) and bring it up
+	lbr0, err = dev.addGatewayAddressToLink("lbr0")
+	if err != nil {
+		return err
+	}
+
+	// Add the link between docker's lbr0 and our OVS bridge
+	dev.vsCtl("del-port", dev.bridgeName, "vovsbr")
+	link := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:   "vlinuxbr",
+			TxQLen: 0,
+		},
+		PeerName: "vovsbr",
+	}
+
+	if err := dev.opHandler.LinkAdd(link); err != nil && err != syscall.EEXIST {
+		return fmt.Errorf("failed to add vlinuxbr/vovsbr veth pair: %v", err)
+	}
+
+	// One side gets attached to lbr0
+	vlinuxbr, err := dev.opHandler.LinkByName("vlinuxbr")
+	if err != nil {
+		return fmt.Errorf("failed to get vlinuxbr: %v", err)
+	}
+	if _, ok := vlinuxbr.(*netlink.Veth); !ok {
+		return fmt.Errorf("vlinuxbr not a veth")
+	}
+	master, ok := lbr0.(*netlink.Bridge)
+	if !ok {
+		return fmt.Errorf("lbr0 not a bridge")
+	}
+	if err := dev.opHandler.LinkSetMaster(vlinuxbr, master); err != nil {
+		return fmt.Errorf("failed to add vlinuxbr to lbr0: %v", err)
+	}
+	if err := dev.opHandler.LinkSetUp(vlinuxbr); err != nil {
+		return fmt.Errorf("failed to bring up vlinuxbr: %v", err)
+	}
+
+	// And the other side to our OVS bridge
+	vovsbr, err := dev.opHandler.LinkByName(link.PeerName)
+	if err != nil {
+		return fmt.Errorf("failed to get vovsbr: %v", err)
+	}
+	if err := dev.opHandler.LinkSetUp(vovsbr); err != nil {
+		return fmt.Errorf("failed to bring up vovsbr: %v", err)
+	}
+
+	if err := dev.vsCtl("add-port", dev.bridgeName, "vovsbr", "--", "set", "Interface", "vovsbr", "ofport_request=3"); err != nil {
+		return fmt.Errorf("failed to attach vovsbr to %s: %v", dev.bridgeName, err)
+	}
+
+	return nil
+}
+
+func (dev *ovsDevice) ensureTun() error {
+	dev.vsCtl("del-port", dev.bridgeName, "tun0")
+	if err := dev.vsCtl("add-port", dev.bridgeName, "tun0", "--", "set", "Interface", "tun0", "type=internal", "ofport_request=2"); err != nil {
+		return fmt.Errorf("failed to add tun0: %v", err)
+	}
+
+	tun0, err := dev.addGatewayAddressToLink("tun0")
+	if err != nil {
+		return err
+	}
+
+	route := netlink.Route{
+		Scope:     netlink.SCOPE_LINK,
+		Dst:       dev.nodeNetwork.ToIPNet(),
+		LinkIndex: tun0.Attrs().Index,
+	}
+
+	if err := dev.opHandler.RouteAdd(&route); err != nil && err != syscall.EEXIST {
+		return fmt.Errorf("failed to add tun0 network route: %v", err)
+	}
+
+	// Set up NAT for containers through tun0
+	if err := dev.opHandler.Sysctl("net.ipv4.ip_forward", "1"); err != nil {
+		return fmt.Errorf("failed to enable IPv4 forwarding: %v", err)
+	}
+	if err := dev.opHandler.Sysctl("net.ipv4.conf.tun0.forwarding", "1"); err != nil {
+		return fmt.Errorf("failed to enable IPv4 forwarding for tun0: %v", err)
+	}
+
+	return nil
+}
+
+// Generate the default gateway IP Address for a subnet
+func generateDefaultGateway(sna *net.IPNet) net.IP {
+	ip := sna.IP.To4()
+	return net.IPv4(ip[0], ip[1], ip[2], ip[3]|0x1)
+}
+
+func (dev *ovsDevice) nodeSetup(clusterNetwork ip.IP4Net, nodeNetwork ip.IP4Net, servicesNetwork *ip.IP4Net) error {
+	dev.clusterNetwork = clusterNetwork
+	dev.nodeNetwork = nodeNetwork
+	dev.servicesNetwork = *servicesNetwork
+	dev.gwAddr = generateDefaultGateway(nodeNetwork.ToIPNet())
+
+	// Finish early if everything is already configured
+	// FIXME: need to be finer-grained about this
+	if lbr0, err := dev.opHandler.LinkByName("lbr0"); err == nil {
+		gwAddrNetlink, _ := netlink.ParseAddr(fmt.Sprintf("%s/%d", dev.gwAddr.String(), dev.nodeNetwork.PrefixLen))
+		if addrs, err := dev.opHandler.AddrList(lbr0, syscall.AF_INET); err == nil {
+			for _, addr := range addrs {
+				if addr.Equal(*gwAddrNetlink) {
+					return nil
+				}
+			}
+		}
+	}
+
+	if err := dev.ensureDockerBridge(); err != nil {
+		return fmt.Errorf("failed docker bridge setup: %v", err)
+	}
+
+	if err := dev.ensureTun(); err != nil {
+		return fmt.Errorf("failed tun0 setup: %v", err)
+	}
+
+	// disable iptables for lbr0
+	// for kernel version 3.18+, module br_netfilter needs to be loaded upfront
+	// for older ones, br_netfilter may not exist, but is covered by bridge (bridge-utils)
+	dev.opHandler.Modprobe("br_netfilter")
+	if err := dev.opHandler.Sysctl("net.bridge.bridge-nf-call-iptables", "0"); err != nil {
+		return fmt.Errorf("failed bridge-nf-call-iptables setup: %v", err)
+	}
+
+	// Clean up any old docker bridge
+	docker0, err := dev.opHandler.LinkByName("docker0")
+	if err == nil {
+		dev.opHandler.LinkDel(docker0)
+	}
+
+	// Table 2; incoming from vxlan
+	dev.addFlow("table=2, priority=200, ip, nw_dst=%s, actions=output:2", dev.gwAddr.String())
+	dev.addFlow("table=2, priority=100, ip, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:6", dev.nodeNetwork.String())
+
+	// Table 4; services; mostly filled in by flannelmt.go
+	dev.addFlow("table=4, priority=100, ip, nw_dst=%s, actions=drop", dev.servicesNetwork.String())
+
+	// Table 5; general routing
+	dev.addFlow("table=5, priority=200, ip, nw_dst=%s, actions=output:2", dev.gwAddr.String())
+	dev.addFlow("table=5, priority=150, ip, nw_dst=%s, actions=goto_table:6", dev.nodeNetwork.String())
+	dev.addFlow("table=5, priority=100, ip, nw_dst=%s, actions=goto_table:7", dev.clusterNetwork.String())
+
+	return nil
+}
+
+func (dev *ovsDevice) genericSetup() error {
+	// Exit early if setup isn't required
+	output, err := dev.ofCtl("dump-flows", "")
+	if err == nil && strings.Index(string(output), "NXM_NX_TUN_IPV4") >= 0 {
+		log.Infof("Skipping generic setup; OVS bridge already initialized")
+		return nil
+	}
+
+	dev.vsCtl("del-br", dev.bridgeName)
+	dev.vsCtl("add-br", dev.bridgeName, "--", "set", "Bridge", dev.bridgeName, "fail-mode=secure")
+	dev.vsCtl("set", "bridge", dev.bridgeName, "protocols=OpenFlow13")
+	dev.vsCtl("del-port", dev.bridgeName, "vxlan0")
+	dev.vsCtl("add-port", dev.bridgeName, "vxlan0", "--", "set", "Interface", "vxlan0", "type=vxlan", "options:remote_ip=\"flow\"", "options:key=\"flow\"", "ofport_request=1")
+
+	link, err := dev.opHandler.LinkByName("br0")
+	if err != nil {
+		return fmt.Errorf("failed to get br0: %v", err)
+	}
+	if err := dev.opHandler.LinkSetUp(link); err != nil {
+		return fmt.Errorf("failed to bring up br0: %v", err)
+	}
+
+	// Table 0; learn MAC addresses and continue with table 1
+	dev.addFlow("table=0, actions=learn(table=8, priority=200, hard_timeout=900, NXM_OF_ETH_DST[]=NXM_OF_ETH_SRC[], load:NXM_NX_TUN_IPV4_SRC[]->NXM_NX_TUN_IPV4_DST[], output:NXM_OF_IN_PORT[]), goto_table:1")
+
+	// Table 1; initial dispatch
+	dev.addFlow("table=1, arp, actions=goto_table:8")
+	dev.addFlow("table=1, in_port=1, actions=goto_table:2") // vxlan0
+	dev.addFlow("table=1, in_port=2, actions=goto_table:5") // tun0
+	dev.addFlow("table=1, in_port=3, actions=goto_table:5") // vovsbr
+	dev.addFlow("table=1, actions=goto_table:3")            // container
+
+	// Table 2; incoming from vxlan
+	dev.addFlow("table=2, arp, actions=goto_table:8")
+	dev.addFlow("table=2, tun_id=0, actions=goto_table:5")
+
+	// Table 3; incoming from container; filled in by openshift-ovs-flannelmt
+
+	// Table 4; services; mostly filled in by flannelmt.go
+	dev.addFlow("table=4, priority=0, actions=goto_table:5")
+
+	// Table 5; general routing
+	dev.addFlow("table=5, priority=0, ip, actions=output:2")
+
+	// Table 6; to local container; mostly filled in by openshift-ovs-flannelmt
+	dev.addFlow("table=6, priority=200, ip, reg0=0, actions=goto_table:8")
+
+	// Table 7; to remote container; filled in by flannelmt.go
+
+	// Table 8; MAC dispatch / ARP, filled in by Table 0's learn() rule
+	// and with per-node vxlan ARP rules by multitenant.go
+	dev.addFlow("table=8, priority=0, arp, actions=flood")
+
+	return nil
+}
+
+func (dev *ovsDevice) Destroy() {
+	dev.vsCtl("del-br", dev.bridgeName)
+}
+
+func generateCookie(ip string) string {
+	ipa, _, err := net.ParseCIDR(ip)
+	if err != nil {
+		ipa = net.ParseIP(ip)
+	}
+	return hex.EncodeToString(ipa.To4())
+}
+
+func (dev *ovsDevice) AddRemoteSubnet(lease *net.IPNet, vtep net.IP) error {
+	cookie := generateCookie(vtep.String())
+
+	if err := dev.addFlow("table=7,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, lease.String(), vtep.String()); err != nil {
+		return err
+	}
+
+	if err := dev.addFlow("table=8,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, lease.String(), vtep.String()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (dev *ovsDevice) RemoveRemoteSubnet(lease *net.IPNet, vtep net.IP) error {
+	cookie := generateCookie(vtep.String())
+
+	dev.delFlows("table=7,cookie=0x%s/0xffffffff", cookie)
+	dev.delFlows("table=8,cookie=0x%s/0xffffffff", cookie)
+	return nil
+}

--- a/backend/ovs/network.go
+++ b/backend/ovs/network.go
@@ -1,0 +1,50 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovs
+
+import (
+	"github.com/coreos/flannel/Godeps/_workspace/src/golang.org/x/net/context"
+
+	"github.com/coreos/flannel/subnet"
+)
+
+type network struct {
+	name  string
+	lease *subnet.Lease
+	mtu   int
+	be    *OVSBackend
+}
+
+func newNetwork(netname string, config *subnet.Config, mtu int, lease *subnet.Lease, be *OVSBackend) (*network, error) {
+	return &network{
+		name:  netname,
+		lease: lease,
+		mtu:   mtu,
+		be:    be,
+	}, nil
+}
+
+func (n *network) Lease() *subnet.Lease {
+	return n.lease
+}
+
+func (n *network) MTU() int {
+	return n.mtu
+}
+
+func (n *network) Run(ctx context.Context) {
+	<-ctx.Done()
+	n.be.removeNetwork(n)
+}

--- a/backend/ovs/ovs-setup.sh
+++ b/backend/ovs/ovs-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+function setup() {
+    ## iptables
+    iptables -D INPUT -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT || true
+    lineno=$(iptables -nvL INPUT --line-numbers | grep "state RELATED,ESTABLISHED" | awk '{print $1}')
+    iptables -I INPUT $lineno -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT
+}
+
+setup

--- a/backend/ovs/ovs.go
+++ b/backend/ovs/ovs.go
@@ -1,0 +1,187 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovs
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	log "github.com/coreos/flannel/Godeps/_workspace/src/github.com/golang/glog"
+	"github.com/coreos/flannel/Godeps/_workspace/src/golang.org/x/net/context"
+
+	"github.com/coreos/flannel/backend"
+	"github.com/coreos/flannel/pkg/ip"
+	"github.com/coreos/flannel/subnet"
+)
+
+const (
+	CLUSTER_NETWORK_NAME = "~~flannel-ovs-cluster-network~~"
+)
+
+type OVSBackend struct {
+	sm         subnet.Manager
+	clusterNet *network
+	dev        *ovsDevice
+	extIface   *backend.ExternalInterface
+	wg         sync.WaitGroup
+}
+
+func init() {
+	backend.Register("ovs", New)
+}
+
+func New(sm subnet.Manager, extIface *backend.ExternalInterface) (backend.Backend, error) {
+	be := &OVSBackend{
+		sm:       sm,
+		extIface: extIface,
+	}
+
+	var err error
+	if be.dev, err = newOVSDevice(); err != nil {
+		return nil, err
+	}
+
+	return be, nil
+}
+
+func (ovsb *OVSBackend) RegisterNetwork(ctx context.Context, netname string, config *subnet.Config) (backend.Network, error) {
+	if netname != CLUSTER_NETWORK_NAME {
+		return nil, fmt.Errorf("this plugin only handles the %s network", CLUSTER_NETWORK_NAME)
+	}
+
+	servicesNetwork, err := parseClusterNetworkConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cluster network %s config: %v", CLUSTER_NETWORK_NAME, err)
+	}
+
+	// Acquire a lease for this node
+	sa := &subnet.LeaseAttrs{
+		PublicIP:    ip.FromIP(ovsb.extIface.ExtAddr),
+		BackendType: "ovs",
+		BackendData: json.RawMessage(""),
+	}
+	lease, err := ovsb.sm.AcquireLease(ctx, CLUSTER_NETWORK_NAME, sa)
+	switch err {
+	case nil:
+		break
+
+	case context.Canceled, context.DeadlineExceeded:
+		return nil, err
+
+	default:
+		return nil, fmt.Errorf("failed to acquire cluster network lease: %v", err)
+	}
+	log.Infof("ClusterNetwork %s found; node subnet is %s", config.Network, lease.Subnet)
+
+	if err := ovsb.dev.nodeSetup(config.Network, lease.Subnet, servicesNetwork); err != nil {
+		return nil, fmt.Errorf("failed to set up local node: %v", err)
+	}
+
+	ovsb.clusterNet, err = newNetwork(netname, config, ovsb.extIface.Iface.MTU, lease, ovsb)
+	if err != nil {
+		return nil, err
+	}
+
+	return ovsb.clusterNet, nil
+}
+
+func parseClusterNetworkConfig(config *subnet.Config) (*ip.IP4Net, error) {
+	if len(config.Backend) == 0 {
+		return nil, fmt.Errorf("no ServicesNetwork specified")
+	}
+
+	var data struct {
+		ServicesNetwork ip.IP4Net
+	}
+
+	if err := json.Unmarshal(config.Backend, &data); err != nil {
+		return nil, fmt.Errorf("could not unmarshal config: %v", err)
+	}
+	return &data.ServicesNetwork, nil
+}
+
+func (ovsb *OVSBackend) watchNodeLeases(ctx context.Context) {
+	evts := make(chan []subnet.Event)
+	ovsb.wg.Add(1)
+	go func() {
+		subnet.WatchLeases(ctx, ovsb.sm, CLUSTER_NETWORK_NAME, nil, evts)
+		log.Infof("WatchNodeLeases exited")
+		ovsb.wg.Done()
+	}()
+
+	log.Errorf("rcrcrc - watching %s\n", CLUSTER_NETWORK_NAME)
+	initialEvtsBatch := <-evts
+	ovsb.handleNodeEvents(initialEvtsBatch)
+
+	for {
+		select {
+		case evtBatch := <-evts:
+			ovsb.handleNodeEvents(evtBatch)
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (ovsb *OVSBackend) removeNetwork(network *network) {
+	ovsb.clusterNet = nil
+}
+
+func (ovsb *OVSBackend) Run(ctx context.Context) {
+	ovsb.wg.Add(1)
+	go func() {
+		ovsb.watchNodeLeases(ctx)
+		ovsb.wg.Done()
+	}()
+
+	<-ctx.Done()
+
+	ovsb.wg.Wait()
+}
+
+func (ovsb *OVSBackend) handleNodeEvents(batch []subnet.Event) {
+	for _, evt := range batch {
+		switch evt.Type {
+		case subnet.EventAdded:
+			log.Infof("Node added: %s => %s", evt.Lease.Attrs.PublicIP, evt.Lease.Subnet)
+
+			if evt.Lease.Attrs.BackendType != "ovs" {
+				log.Warningf("Ignoring non-ovs subnet: type=%v", evt.Lease.Attrs.BackendType)
+				continue
+			}
+
+			if ovsb.extIface.IfaceAddr.String() != evt.Lease.Attrs.PublicIP.String() {
+				ovsb.dev.AddRemoteSubnet(evt.Lease.Subnet.ToIPNet(), evt.Lease.Attrs.PublicIP.ToIP())
+			}
+
+		case subnet.EventRemoved:
+			log.Infof("Node removed: %s => %s", evt.Lease.Attrs.PublicIP, evt.Lease.Subnet)
+
+			if evt.Lease.Attrs.BackendType != "ovs" {
+				log.Warningf("Ignoring non-ovs subnet: type=%v", evt.Lease.Attrs.BackendType)
+				continue
+			}
+
+			if ovsb.extIface.IfaceAddr.String() != evt.Lease.Attrs.PublicIP.String() {
+				ovsb.dev.RemoveRemoteSubnet(evt.Lease.Subnet.ToIPNet(), evt.Lease.Attrs.PublicIP.ToIP())
+			}
+
+		default:
+			log.Error("Internal error: unknown event type: ", int(evt.Type))
+		}
+	}
+}

--- a/backend/ovs/ovs_test.go
+++ b/backend/ovs/ovs_test.go
@@ -1,0 +1,888 @@
+// Copyright 2015 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovs
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"unicode"
+
+	"github.com/coreos/flannel/Godeps/_workspace/src/github.com/vishvananda/netlink"
+
+	"github.com/coreos/flannel/pkg/ip"
+)
+
+//*****************************************************************************
+
+type ovsPort struct {
+	name  string
+	ptype string
+	port  int
+}
+
+type testLink struct {
+	link   netlink.Link
+	addrs  []netlink.Addr
+	routes []netlink.Route
+}
+
+type testOpHandler struct {
+	bridge   string
+	proto    string
+	nextLink int
+	links    map[string]*testLink
+	ovsPorts map[string]*ovsPort
+	ovsFlows []string
+	sysctls  map[string]string
+}
+
+type ovsFunc func(h *testOpHandler, args []string) ([]byte, error)
+
+var vsCtlMap = map[string]ovsFunc{
+	"add-br":   vsAddBr,
+	"del-br":   vsDelBr,
+	"set":      vsSet,
+	"add-port": vsAddPort,
+	"del-port": vsDelPort,
+}
+
+var tt *testing.T
+
+func vsAddBr(h *testOpHandler, args []string) ([]byte, error) {
+	if h.bridge != "" || len(h.ovsPorts) > 0 || len(h.ovsFlows) > 0 {
+		return nil, fmt.Errorf("OVS bridge already exists")
+	}
+
+	h.bridge = args[0]
+	h.links = make(map[string]*testLink)
+	h.ovsPorts = make(map[string]*ovsPort)
+	h.sysctls = make(map[string]string)
+	h.nextLink = 1
+
+	// Add the corresponding kernel link
+	link := &netlink.Device{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: h.bridge,
+		},
+	}
+	err := h.LinkAdd(link)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func vsDelBr(h *testOpHandler, args []string) ([]byte, error) {
+	// Delete kernel link
+	if _, ok := h.links[h.bridge]; ok {
+		delete(h.links, h.bridge)
+	}
+
+	for k := range h.ovsPorts {
+		delete(h.ovsPorts, k)
+	}
+	h.ovsFlows = nil
+	h.sysctls = nil
+	h.bridge = ""
+	return nil, nil
+}
+
+func vsSet(h *testOpHandler, args []string) ([]byte, error) {
+	for _, a := range args {
+		if strings.HasPrefix(a, "protocols=") {
+			h.proto = a[10:]
+		}
+	}
+	return nil, nil
+}
+
+func (h *testOpHandler) ovsPortExists(port int) bool {
+	for _, p := range h.ovsPorts {
+		if p.port == port {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *testOpHandler) nextOvsPort() (int, error) {
+	// OVS always starts added ports at 1 because 0 is the LOCAL port (the bridge itself)
+	for i := 1; i < 1000; i++ {
+		if !h.ovsPortExists(i) {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("Exhausted available OVS port numbers")
+}
+
+func vsAddPort(h *testOpHandler, args []string) ([]byte, error) {
+	name := args[1]
+	if _, ok := h.ovsPorts[name]; ok {
+		return nil, fmt.Errorf("Bridge port %s already exists", name)
+	}
+	port := &ovsPort{
+		name: name,
+		port: -1,
+	}
+	addLink := false
+	for _, a := range args {
+		if strings.HasPrefix(a, "type=") {
+			port.ptype = a[5:]
+
+			// only type=internal ports get created as a netdev
+			if port.ptype == "internal" {
+				addLink = true
+			}
+		} else if strings.HasPrefix(a, "ofport_request=1") {
+			pnum, err := strconv.ParseInt(a[15:], 10, 32)
+			if err == nil {
+				// ovs-vsctl assigns a new port number if the
+				// requested one is taken
+				if !h.ovsPortExists(int(pnum)) {
+					port.port = int(pnum)
+				}
+			}
+		}
+	}
+
+	if port.port < 0 {
+		port.port, _ = h.nextOvsPort()
+	}
+
+	h.ovsPorts[name] = port
+
+	if addLink {
+		// Add the corresponding kernel link
+		link := &netlink.Device{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: name,
+			},
+		}
+		err := h.LinkAdd(link)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
+}
+
+func vsDelPort(h *testOpHandler, args []string) ([]byte, error) {
+	name := args[1]
+	if _, ok := h.ovsPorts[name]; !ok {
+		return nil, fmt.Errorf("Bridge port %s does not exist", name)
+	}
+	delete(h.ovsPorts, name)
+
+	// Delete kernel link
+	if _, ok := h.links[name]; ok {
+		delete(h.links, name)
+	}
+
+	return nil, nil
+}
+
+func (h *testOpHandler) vsCtl(args ...string) ([]byte, error) {
+	funcName := args[0]
+	vsfunc, ok := vsCtlMap[funcName]
+	if !ok {
+		tt.Errorf("Unknown ovs-vsctl command %s", funcName)
+	}
+	bridgeIndex := 1
+	if funcName == "set" {
+		bridgeIndex = 2
+	}
+	if h.bridge != "" && args[bridgeIndex] != h.bridge {
+		return nil, fmt.Errorf("Unexpected switch name %s", args[bridgeIndex])
+	}
+
+	return vsfunc(h, args[bridgeIndex:])
+}
+
+var ofCtlMap = map[string]ovsFunc{
+	"add-flow":   ofAddFlow,
+	"del-flows":  ofDelFlows,
+	"dump-ports": ofDumpPorts,
+	"dump-flows": ofDumpFlows,
+}
+
+func canonicalizeFlow(flow string) string {
+	var buffer bytes.Buffer
+	for _, c := range flow {
+		if !unicode.IsSpace(c) {
+			buffer.WriteString(fmt.Sprintf("%c", c))
+		}
+	}
+	return buffer.String()
+}
+
+func ofAddFlow(h *testOpHandler, args []string) ([]byte, error) {
+	// Strip internal spaces
+	if len(args) != 1 {
+		return nil, fmt.Errorf("Expected only one flow argument (got %d)", len(args))
+	}
+
+	h.ovsFlows = append(h.ovsFlows, canonicalizeFlow(args[0]))
+
+	return nil, nil
+}
+
+// Returns table # and cookie of the flow
+func parseFlow(flow string) (string, string, error) {
+	var table string
+	var cookie string
+
+	for _, p := range strings.Split(flow, ",") {
+		if strings.HasPrefix(p, "table=") {
+			table = p[6:]
+		} else if strings.HasPrefix(p, "cookie=0x") {
+			slash := strings.Index(p, "/")
+			if slash >= 0 && slash <= 9 {
+				return "", "", fmt.Errorf("Invalid OVS flow to delete; cookie format wrong: %s", flow)
+			} else if slash > 9 {
+				cookie = p[9:slash]
+			} else {
+				cookie = p[9:]
+			}
+		}
+		if table != "" && cookie != "" {
+			break
+		}
+	}
+	return table, cookie, nil
+}
+
+func ofDelFlows(h *testOpHandler, args []string) ([]byte, error) {
+	table, cookie, err := parseFlow(args[0])
+	if err != nil {
+		return nil, err
+	}
+
+loop:
+	for idx, f := range h.ovsFlows {
+		matchedTable := true
+		matchedCookie := true
+		ct, cc, _ := parseFlow(f)
+		if table != "" && table != ct {
+			matchedTable = false
+		}
+		if cookie != "" && cookie != cc {
+			matchedCookie = false
+		}
+		if matchedTable && matchedCookie {
+			h.ovsFlows = append(h.ovsFlows[:idx], h.ovsFlows[idx+1:]...)
+			goto loop
+		}
+	}
+
+	return nil, nil
+}
+
+type ovsPortSort []*ovsPort
+
+func (s ovsPortSort) Len() int {
+	return len(s)
+}
+
+func (s ovsPortSort) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ovsPortSort) Less(i, j int) bool {
+	return s[i].port < s[j].port
+}
+
+func ofDumpPorts(h *testOpHandler, args []string) ([]byte, error) {
+	var buffer bytes.Buffer
+
+	dumpPorts := make(ovsPortSort, 0, 10)
+	if len(args) == 1 {
+		port, ok := h.ovsPorts[args[0]]
+		if !ok {
+			buffer.WriteString(fmt.Sprintf("ovs-ofctl: br0: couldn't find port `%s'", args[0]))
+			return buffer.Bytes(), nil
+		}
+		dumpPorts = append(dumpPorts, port)
+	} else {
+		for _, port := range h.ovsPorts {
+			if len(args) == 1 && port.name == args[0] {
+				break
+			}
+		}
+		sort.Sort(ovsPortSort(dumpPorts))
+	}
+
+	buffer.WriteString(fmt.Sprintf("OFPST_PORT reply (xid=0x1): %s ports\n", len(h.ovsPorts)))
+	for _, port := range dumpPorts {
+		buffer.WriteString(fmt.Sprintf("port %d: rx pkts=33, bytes=5785, drop=0, errs=0, frame=0, over=0, crc=0\n", port.port))
+		buffer.WriteString("         tx pkts=730, bytes=56061, drop=0, errs=0, coll=0\n")
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ofDumpFlows(h *testOpHandler, args []string) ([]byte, error) {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("OFPST_FLOW reply (OF1.3) (xid=0x2):\n")
+	for _, flow := range h.ovsFlows {
+		buffer.WriteString(fmt.Sprintf(" duration=5.690s, %s\n", flow))
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (h *testOpHandler) ofCtl(args ...string) ([]byte, error) {
+	funcName := args[2]
+	offunc, ok := ofCtlMap[funcName]
+	if !ok {
+		tt.Fatalf("Unknown ovs-ofctl command %s", funcName)
+	}
+	if args[0] != "-O" {
+		tt.Fatalf("Expected OpenFlow protocol flag -O at position 1")
+	}
+	bridgeName := args[3]
+	if h.bridge == "" {
+		var buffer bytes.Buffer
+
+		buffer.WriteString(fmt.Sprintf("ovs-ofctl: %s is not a bridge or a socket", bridgeName))
+		return buffer.Bytes(), nil
+	} else {
+		if args[1] != h.proto {
+			tt.Fatalf("Unexpected OpenFlow protocol %s (have %s)", args[1], h.proto)
+		}
+		if bridgeName != h.bridge {
+			tt.Fatalf("Unexpected bridge name %s", bridgeName)
+		}
+	}
+
+	return offunc(h, args[4:])
+}
+
+func (h *testOpHandler) OvsExec(cmd string, args ...string) ([]byte, error) {
+	switch cmd {
+	case "ovs-vsctl":
+		return h.vsCtl(args...)
+	case "ovs-ofctl":
+		return h.ofCtl(args...)
+	}
+	tt.Fatalf("Unknown OVS command %s", cmd)
+	return nil, fmt.Errorf("Unknown OVS command %s", cmd)
+}
+
+func (h *testOpHandler) Modprobe(module string) ([]byte, error) {
+	return nil, nil
+}
+
+func (h *testOpHandler) LinkAdd(link netlink.Link) error {
+	base := link.Attrs()
+	if _, ok := h.links[base.Name]; ok {
+		return syscall.Errno(syscall.EEXIST)
+	}
+
+	var peerName string
+	if veth, ok := link.(*netlink.Veth); ok {
+		if _, ok := h.links[veth.PeerName]; ok {
+			return syscall.Errno(syscall.EEXIST)
+		}
+		peerName = veth.PeerName
+	}
+
+	base.Index = h.nextLink
+	h.nextLink += 1
+
+	h.links[base.Name] = &testLink{
+		link: link,
+	}
+
+	if peerName != "" {
+		// Add the peer
+		peer := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:   peerName,
+				TxQLen: base.TxQLen,
+				Index:  h.nextLink,
+			},
+			PeerName: base.Name,
+		}
+		h.nextLink += 1
+
+		h.links[peerName] = &testLink{
+			link: peer,
+		}
+	}
+
+	return nil
+}
+
+func (h *testOpHandler) LinkDel(link netlink.Link) error {
+	base := link.Attrs()
+	if _, ok := h.links[base.Name]; ok {
+		return syscall.Errno(syscall.EEXIST)
+	}
+
+	var peerName string
+	if veth, ok := link.(*netlink.Veth); ok {
+		if _, ok := h.links[veth.PeerName]; ok {
+			return syscall.Errno(syscall.EEXIST)
+		}
+		peerName = veth.PeerName
+	}
+
+	delete(h.links, base.Name)
+	if peerName != "" {
+		delete(h.links, peerName)
+	}
+
+	return nil
+}
+
+func (h *testOpHandler) LinkByName(name string) (netlink.Link, error) {
+	link, ok := h.links[name]
+	if !ok {
+		return nil, syscall.Errno(syscall.ENOENT)
+	}
+	return link.link, nil
+}
+
+func (h *testOpHandler) LinkByIndex(index int) (netlink.Link, error) {
+	for _, l := range h.links {
+		if index == l.link.Attrs().Index {
+			return l.link, nil
+		}
+	}
+	return nil, syscall.Errno(syscall.ENOENT)
+}
+
+func (h *testOpHandler) LinkSetUp(link netlink.Link) error {
+	base := link.Attrs()
+	found, ok := h.links[base.Name]
+	if !ok {
+		return syscall.Errno(syscall.ENOENT)
+	}
+	found.link.Attrs().Flags |= net.FlagUp
+	return nil
+}
+
+func (h *testOpHandler) LinkSetMaster(link netlink.Link, master *netlink.Bridge) error {
+	base := link.Attrs()
+	found, ok := h.links[base.Name]
+	if !ok {
+		return syscall.Errno(syscall.ENOENT)
+	}
+	found.link.Attrs().MasterIndex = master.Index
+	return nil
+}
+
+func (h *testOpHandler) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
+	base := link.Attrs()
+	found, ok := h.links[base.Name]
+	if !ok {
+		return syscall.Errno(syscall.ENOENT)
+	}
+
+	for _, a := range found.addrs {
+		if a.Equal(*addr) {
+			return syscall.Errno(syscall.EEXIST)
+		}
+	}
+	found.addrs = append(found.addrs, *addr)
+
+	// Add the subnet route for this address too
+	if i, n, err := net.ParseCIDR(strings.TrimSpace(addr.String())); err == nil {
+		route := netlink.Route{
+			Scope:     netlink.SCOPE_LINK,
+			Dst:       n,
+			Src:       i,
+			LinkIndex: base.Index,
+		}
+		h.RouteAdd(&route)
+	}
+
+	return nil
+}
+
+func (h *testOpHandler) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	base := link.Attrs()
+	found, ok := h.links[base.Name]
+	if !ok {
+		return nil, syscall.Errno(syscall.ENOENT)
+	}
+
+	return found.addrs, nil
+}
+
+func (h *testOpHandler) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
+	base := link.Attrs()
+	found, ok := h.links[base.Name]
+	if !ok {
+		return nil, syscall.Errno(syscall.ENOENT)
+	}
+
+	return found.routes, nil
+}
+
+func (h *testOpHandler) findByIndex(index int) (*testLink, error) {
+	for _, l := range h.links {
+		if l.link.Attrs().Index == index {
+			return l, nil
+		}
+	}
+	return nil, syscall.Errno(syscall.ENOENT)
+}
+
+func (h *testOpHandler) RouteAdd(route *netlink.Route) error {
+	found, err := h.findByIndex(route.LinkIndex)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range found.routes {
+		if reflect.DeepEqual(r, route) {
+			return syscall.Errno(syscall.EEXIST)
+		}
+	}
+	found.routes = append(found.routes, *route)
+	return nil
+}
+
+func (h *testOpHandler) RouteDel(route *netlink.Route) error {
+	found, err := h.findByIndex(route.LinkIndex)
+	if err != nil {
+		return err
+	}
+
+	for idx, r := range found.routes {
+		if reflect.DeepEqual(r, route) {
+			// Delete route from the list
+			found.routes = append(found.routes[:idx], found.routes[idx+1:]...)
+			return nil
+		}
+	}
+	return syscall.Errno(syscall.ENOENT)
+}
+
+func (h *testOpHandler) RouteDelWithProtocol(route *netlink.Route, protocol uint8) error {
+	return h.RouteDel(route)
+}
+
+func (h *testOpHandler) Sysctl(item, value string) error {
+	h.sysctls[item] = value
+	return nil
+}
+
+func (h *testOpHandler) MatchSwitchConfig(name string, ports []ovsPort) error {
+	if name != h.bridge {
+		return fmt.Errorf("Bad bridge name %s (expected %s)", h.bridge, name)
+	}
+
+	if len(ports) != len(h.ovsPorts) {
+		return fmt.Errorf("Expected ports %d doesn't match found ports %d", len(ports), len(h.ovsPorts))
+	}
+
+	for _, expected := range ports {
+		found, ok := h.ovsPorts[expected.name]
+		if !ok {
+			return fmt.Errorf("Failed to find expected port %s", expected.name)
+		}
+		if found.name != expected.name {
+			return fmt.Errorf("Bad port name %s (expected %s)", found.name, expected.name)
+		}
+		if found.ptype != expected.ptype {
+			return fmt.Errorf("Bad port type %s (expected %s)", found.ptype, expected.ptype)
+		}
+		if found.port != expected.port {
+			return fmt.Errorf("Bad port number %s (expected %s)", found.port, expected.port)
+		}
+	}
+	return nil
+}
+
+func (h *testOpHandler) MatchFlows(flows []string) error {
+	tmp := make(map[string]bool)
+	for _, k := range h.ovsFlows {
+		tmp[k] = false
+	}
+
+	for _, expected := range flows {
+		expected := canonicalizeFlow(expected)
+		found := false
+		for _, candidate := range h.ovsFlows {
+			if expected == candidate {
+				tmp[candidate] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("Unmatched expected flow '%s'", expected)
+		}
+	}
+
+	for k := range tmp {
+		if tmp[k] != true {
+			return fmt.Errorf("Unmatched flow in OVS table '%s'", k)
+		}
+	}
+
+	if len(flows) != len(h.ovsFlows) {
+		return fmt.Errorf("Expected flows %d doesn't match found flows %d", len(flows), len(h.ovsFlows))
+	}
+
+	return nil
+}
+
+func newTestOpHandler() *testOpHandler {
+	return &testOpHandler{
+		ovsPorts: make(map[string]*ovsPort),
+		links:    make(map[string]*testLink),
+		sysctls:  make(map[string]string),
+		nextLink: 1,
+	}
+}
+
+//*****************************************************************************
+
+type expectedLink struct {
+	ip      string
+	ovsType string
+}
+
+func IPNetFromString(cidr string) *net.IPNet {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		tt.Fatalf("Failed to parse IP address %s: %v", cidr, err)
+	}
+	return ipnet
+}
+
+func TestOVSBridge(t *testing.T) {
+	tt = t
+	opHandler := newTestOpHandler()
+	dev, err := newOVSDeviceWithHandler(opHandler)
+	if err != nil {
+		t.Fatalf("Failed to create OVS bridge device: %s", err)
+	}
+
+	// Only one kernel link: br0
+	if len(opHandler.links) != 1 {
+		t.Fatalf("Found unexpected number of kernel links %d (expected 1)", len(opHandler.links))
+	}
+
+	expectedPorts := []ovsPort{
+		{"vxlan0", "vxlan", 1},
+	}
+	if err := opHandler.MatchSwitchConfig("br0", expectedPorts); err != nil {
+		t.Fatalf("Failed to match vswitch config: %s", err)
+	}
+
+	expectedFlows := []string{
+		"table=0, actions=learn(table=8, priority=200, hard_timeout=900, NXM_OF_ETH_DST[]=NXM_OF_ETH_SRC[], load:NXM_NX_TUN_IPV4_SRC[]->NXM_NX_TUN_IPV4_DST[], output:NXM_OF_IN_PORT[]), goto_table:1",
+		"table=1, arp, actions=goto_table:8",
+		"table=1, in_port=1, actions=goto_table:2",
+		"table=1, in_port=2, actions=goto_table:5",
+		"table=1, in_port=3, actions=goto_table:5",
+		"table=1, actions=goto_table:3",
+		"table=2, arp, actions=goto_table:8",
+		"table=2, tun_id=0, actions=goto_table:5",
+		"table=4, priority=0, actions=goto_table:5",
+		"table=5, priority=0, ip, actions=output:2",
+		"table=6, priority=200, ip, reg0=0, actions=goto_table:8",
+		"table=8, priority=0, arp, actions=flood",
+	}
+	if err := opHandler.MatchFlows(expectedFlows); err != nil {
+		t.Fatalf("Failed to match flows: %s", err)
+	}
+
+	// Do final node setup
+	clusterNetwork := ip.FromIPNet(IPNetFromString("10.1.0.0/16"))
+	nodeNetwork := ip.FromIPNet(IPNetFromString("10.1.55.0/24"))
+	servicesNetwork := ip.FromIPNet(IPNetFromString("172.16.1.0/24"))
+	if err := dev.nodeSetup(clusterNetwork, nodeNetwork, &servicesNetwork); err != nil {
+		t.Fatalf("Failed to add network to device: %s", err)
+	}
+
+	gwAddr := "10.1.55.1"
+	gwCidr := fmt.Sprintf("%s/24", gwAddr)
+
+	// Should now have a bunch of links now: br0, lbr0, vovsbr, vlinuxbr, tun0
+	expectedLinks := make(map[string]expectedLink)
+	expectedLinks["br0"] = expectedLink{"", ""}
+	expectedLinks["lbr0"] = expectedLink{gwCidr, ""}
+	expectedLinks["vovsbr"] = expectedLink{"", ""}
+	expectedLinks["vlinuxbr"] = expectedLink{"", ""}
+	expectedLinks["tun0"] = expectedLink{gwCidr, "internal"}
+
+	if len(opHandler.links) != len(expectedLinks) {
+		t.Fatalf("Found unexpected number of kernel links %d (expected %d)", len(opHandler.links), len(expectedLinks))
+	}
+
+	for name, el := range expectedLinks {
+		l, ok := opHandler.links[name]
+		if !ok {
+			t.Fatalf("Failed to find kernel link %s", name)
+		}
+		if el.ip != "" {
+			if len(l.addrs) != 1 {
+				t.Fatalf("Unexpected number of IP address on %s: %d", name, len(l.addrs))
+			}
+			// netlink's String() adds a space at the end...
+			if strings.TrimSpace(l.addrs[0].String()) != el.ip {
+				t.Fatalf("Mismatched IP address on %s: %s (expected %s)", name, l.addrs[0].String(), el.ip)
+			}
+		} else if len(l.addrs) != 0 {
+			t.Fatalf("Unexpected IP address on %s: %s", name, l.addrs[0].String())
+		}
+
+		if l.link.Attrs().Flags&net.FlagUp == 0 {
+			t.Fatalf("Link %s was not UP", name)
+		}
+
+		if el.ovsType != "" {
+			o, ok := opHandler.ovsPorts[name]
+			if !ok {
+				t.Fatalf("Failed to find OVS link %s", name)
+			}
+			if o.ptype != el.ovsType {
+				t.Fatalf("Unexpected OVS link %s type %s (expected %s)", name, o.ptype, el.ovsType)
+			}
+		}
+	}
+
+	// Sysctls
+	expectedSysctls := make(map[string]string)
+	expectedSysctls["net.bridge.bridge-nf-call-iptables"] = "0"
+	expectedSysctls["net.ipv4.ip_forward"] = "1"
+	expectedSysctls["net.ipv4.conf.tun0.forwarding"] = "1"
+
+	if len(opHandler.sysctls) != len(expectedSysctls) {
+		t.Fatalf("Found unexpected number of sysctls %d (expected %d)", len(opHandler.sysctls), len(expectedSysctls))
+	}
+
+	for item, value := range expectedSysctls {
+		sc, ok := opHandler.sysctls[item]
+		if !ok {
+			t.Fatalf("Failed to find sysctl %s", item)
+		}
+		if sc != value {
+			t.Fatalf("Unexpected sysctl %s value %s (expected %s)", item, sc, value)
+		}
+	}
+
+	nodeFlows := []string{
+		fmt.Sprintf("table=2, priority=200, ip, nw_dst=%s, actions=output:2", gwAddr),
+		fmt.Sprintf("table=2, priority=100, ip, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:6", nodeNetwork.String()),
+		fmt.Sprintf("table=4, priority=100, ip, nw_dst=%s, actions=drop", servicesNetwork.String()),
+		fmt.Sprintf("table=5, priority=200, ip, nw_dst=%s, actions=output:2", gwAddr),
+		fmt.Sprintf("table=5, priority=150, ip, nw_dst=%s, actions=goto_table:6", nodeNetwork.String()),
+		fmt.Sprintf("table=5, priority=100, ip, nw_dst=%s, actions=goto_table:7", clusterNetwork.String()),
+	}
+	for _, f := range expectedFlows {
+		nodeFlows = append(nodeFlows, f)
+	}
+
+	if err := opHandler.MatchFlows(nodeFlows); err != nil {
+		t.Fatalf("Failed to match node flows: %s", err)
+	}
+
+}
+
+func TestSkipOVSSetup(t *testing.T) {
+	tt = t
+	opHandler := newTestOpHandler()
+
+	// Add one bogus flow and make sure the bridge doesn't add any more
+	_, err := opHandler.OvsExec("ovs-vsctl", "add-br", "br0", "--", "set", "Bridge", "br0")
+	if err != nil {
+		tt.Fatalf("Failed to add OVS bridge: %v", err)
+	}
+	_, err = opHandler.OvsExec("ovs-vsctl", "set", "bridge", "br0", "protocols=OpenFlow13")
+	if err != nil {
+		tt.Fatalf("Failed to set OVS bridge protocol: %v", err)
+	}
+
+	flow := "table=0, actions=learn(table=8, priority=200, hard_timeout=900, NXM_OF_ETH_DST[]=NXM_OF_ETH_SRC[], load:NXM_NX_TUN_IPV4_SRC[]->NXM_NX_TUN_IPV4_DST[], output:NXM_OF_IN_PORT[]), goto_table:1"
+	opHandler.ofCtl("-O", "OpenFlow13", "add-flow", "br0", flow)
+
+	// Let the device try to configure the bridge
+	_, err = newOVSDeviceWithHandler(opHandler)
+	if err != nil {
+		t.Fatalf("Failed to create OVS bridge device: %s", err)
+	}
+
+	if len(opHandler.ovsFlows) != 1 {
+		t.Fatalf("OVS bridge flows unexpectedly configured")
+	}
+}
+
+func TestSkipNodeSetup(t *testing.T) {
+	tt = t
+	opHandler := newTestOpHandler()
+	dev, err := newOVSDeviceWithHandler(opHandler)
+	if err != nil {
+		t.Fatalf("Failed to create OVS bridge device: %s", err)
+	}
+
+	clusterNetwork := ip.FromIPNet(IPNetFromString("10.1.0.0/16"))
+	nodeNetwork := ip.FromIPNet(IPNetFromString("10.1.55.0/24"))
+	servicesNetwork := ip.FromIPNet(IPNetFromString("172.16.1.0/24"))
+
+	// Add lbr0 and the gateway address and make sure no other interfaces get created
+	tmp := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: "lbr0",
+		},
+	}
+	if err := opHandler.LinkAdd(tmp); err != nil {
+		t.Fatalf("failed to add lbr0: %v", err)
+	}
+
+	lbr0, ok := opHandler.links["lbr0"]
+	if !ok {
+		t.Fatalf("lbr0 not added")
+	}
+
+	addr, err := netlink.ParseAddr("10.1.55.1/24")
+	err = opHandler.AddrAdd(lbr0.link, addr)
+	if err != nil {
+		t.Fatalf("failed to parse gateway address %s: %v", addr.String(), err)
+	}
+
+	// Let the device do node setup
+	if err := dev.nodeSetup(clusterNetwork, nodeNetwork, &servicesNetwork); err != nil {
+		t.Fatalf("Failed to add network to device: %s", err)
+	}
+
+	// Ensure we only have br0 and lbr0
+	if len(opHandler.links) != 2 {
+		t.Fatalf("Unexpected number of links %d (expected 2)", len(opHandler.links))
+	}
+
+	if _, ok := opHandler.links["br0"]; !ok {
+		t.Fatalf("Couldn't find br0")
+	}
+
+	if _, ok := opHandler.links["lbr0"]; !ok {
+		t.Fatalf("Couldn't find lbr0")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/coreos/flannel/backend/awsvpc"
 	_ "github.com/coreos/flannel/backend/gce"
 	_ "github.com/coreos/flannel/backend/hostgw"
+	_ "github.com/coreos/flannel/backend/ovs"
 	_ "github.com/coreos/flannel/backend/udp"
 	_ "github.com/coreos/flannel/backend/vxlan"
 )

--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="pkg/ip subnet network remote"
+TESTABLE="pkg/ip subnet network remote backend/ovs"
 FORMATTABLE="$TESTABLE"
 
 # user has not provided PKG override


### PR DESCRIPTION
Reworked for @eyakubovich  comments; the fake networks have been removed and the code simplified.  Without the fake networks the plugin only needs to handle a single network, the cluster network.  I chose to keep that network using a well-known network name for a couple reasons:

1) OpenShift or Kubernetes only allow one container orchestration instance running at a given time on a given node anyway; that means a single 'network' controlled by this backend.  No great reason to allow that name to be configurable.

2) this plugin only configures the OVS bridge and associated interfaces; it does not have anything to do with the actual containers.  The container orchestrator must know a few things in common with this plugin; at least the flannel network name (so that it can write the cluster network and services network to etcd that flannel reads) and the OVS bridge device name (so that it can attach containers to the OVS interface).  Since there can be only one network, and one OVS bridge at this time, they are hardcoded.  (yes, we could make the OVS bridge and associated device names dynamic and write them to the subnet file I guess?  Seems like a lot of work for no reason...)

Also, perhaps we need a better name than 'ovs' since there could be other plugins that use OVS for something else, that aren't this one.  But I'd rather not have 'openshift' since we're hoping to spin this out to pure Kubernetes+flannel.  kube-ovs-multitenant?  Something else?

Thoughts?
