### PR TITLE
[security] Fix UDP binding interface

### DIFF
--- a/backend/udp/network.go
+++ b/backend/udp/network.go
@@ -64,7 +64,7 @@ func newNetwork(name string, sm subnet.Manager, extIface *backend.ExternalInterf
 	}
 
 	var err error
-	n.conn, err = net.ListenUDP("udp4", &net.UDPAddr{Port: port})
+	n.conn, err = net.ListenUDP("udp4", &net.UDPAddr{IP: extIface.IfaceAddr, Port: port})
 	if err != nil {
 		return nil, fmt.Errorf("failed to start listening on UDP socket: %v", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/coreos/flannel/issues/394 , a bug that makes the UDP backend bind to 0.0.0.0 instead of to the specified interface.

If flannel is running over a VPN but the nodes also have an external public non-VPN IP (on which flannel should not be reachable), this is a severe security issue.