### PR TITLE
Convert vxlan port to big endian

### DIFF
--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -59,7 +59,7 @@ func newVXLANDevice(devAttrs *vxlanDeviceAttrs) (*vxlanDevice, error) {
 		VxlanId:      int(devAttrs.vni),
 		VtepDevIndex: devAttrs.vtepIndex,
 		SrcAddr:      devAttrs.vtepAddr,
-		Port:         devAttrs.vtepPort,
+		Port:         int(nl.Swap16(uint16(devAttrs.vtepPort))), //network endian order
 		Learning:     false,
 	}
 


### PR DESCRIPTION
When I use flannel create network with port 8472 , vxlan module will listen on UDP port 6177. We should convert vxlan port to big endian when create vxlan device. This PR fix this bug.

Signed-off-by: Ye Yin <eyniy@qq.com>