### PR TITLE
Remove race-condition when setting up masquerade rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ $ flanneld --remote=10.0.0.3:8888 --networks=blue,green
 --etcd-cafile="": SSL Certificate Authority file used to secure etcd communication.
 --iface="": interface to use (IP or name) for inter-host communication. Defaults to the interface for the default route on the machine.
 --subnet-file=/run/flannel/subnet.env: filename where env variables (subnet and MTU values) will be written to.
---ip-masq=false: setup IP masquerade for traffic destined for outside the flannel network.
+--ip-masq=false: setup IP masquerade for traffic destined for outside the flannel network. Flannel assumes that the default policy is ACCEPT in the NAT POSTROUTING chain.
 --listen="": if specified, will run in server mode. Value is IP and port (e.g. `0.0.0.0:8888`) to listen on or `fd://` for [socket activation](http://www.freedesktop.org/software/systemd/man/systemd.socket.html).
 --remote="": if specified, will run in client mode. Value is IP and port of the server.
 --remote-keyfile="": SSL key file used to secure client/server communication.

--- a/network/ipmasq.go
+++ b/network/ipmasq.go
@@ -29,7 +29,7 @@ func rules(ipn ip.IP4Net) [][]string {
 
 	return [][]string{
 		// This rule makes sure we don't NAT traffic within overlay network (e.g. coming out of docker0)
-		{"-s", n, "-d", n, "-j", "ACCEPT"},
+		{"-s", n, "-d", n, "-j", "RETURN"},
 		// NAT if it's not multicast traffic
 		{"-s", n, "!", "-d", "224.0.0.0/4", "-j", "MASQUERADE"},
 		// Masquerade anything headed towards flannel from the host


### PR DESCRIPTION
Using ACCEPT means that no other rules in the POSTROUTING chain can
fire. Using RETURN allows other rules to be run (but relies on default
being ACCEPT which is the norm)