### PR TITLE
Support quorum read option

### DIFF
--- a/subnet/mock_etcd_test.go
+++ b/subnet/mock_etcd_test.go
@@ -127,7 +127,7 @@ func TestMockEtcd(t *testing.T) {
 	// Sanity tests for our mock etcd
 
 	// Ensure no entries yet exist
-	opts := &etcd.GetOptions{Recursive: true}
+	opts := &etcd.GetOptions{Recursive: true, Quorum: true}
 	r, err := m.Get(ctx, "/", opts)
 	e := &etcd.Response{Action: "get", Index: 1000, Node: m.nodes["/"]}
 	expectSuccess(t, r, err, e, "")
@@ -159,7 +159,7 @@ func TestMockEtcd(t *testing.T) {
 
 	// Get it again
 	expectedNode := r.Node
-	opts = &etcd.GetOptions{Recursive: false}
+	opts = &etcd.GetOptions{Recursive: false, Quorum: true}
 	r, err = m.Get(ctx, netKey2, opts)
 	e = &etcd.Response{Action: "get", Index: m.index, Node: expectedNode}
 	expectSuccess(t, r, err, e, netValue)
@@ -171,13 +171,13 @@ func TestMockEtcd(t *testing.T) {
 	expectSuccess(t, r, err, e, netValue)
 
 	// Get it again
-	opts = &etcd.GetOptions{Recursive: false}
+	opts = &etcd.GetOptions{Recursive: false, Quorum: true}
 	r, err = m.Get(ctx, netKey2, opts)
 	e = &etcd.Response{Action: "get", Index: m.index}
 	expectSuccess(t, r, err, e, netValue)
 
 	// test directory listing
-	opts = &etcd.GetOptions{Recursive: true}
+	opts = &etcd.GetOptions{Recursive: true, Quorum: true}
 	r, err = m.Get(ctx, "/coreos.com/network/", opts)
 	e = &etcd.Response{Action: "get", Index: 1007}
 	expectSuccess(t, r, err, e, "")
@@ -220,7 +220,7 @@ func TestMockEtcd(t *testing.T) {
 	expectSuccess(t, r, err, e, "")
 
 	// Get it again; should fail
-	opts = &etcd.GetOptions{Recursive: false}
+	opts = &etcd.GetOptions{Recursive: false, Quorum: true}
 	r, err = m.Get(ctx, netKey1, opts)
 	if err == nil {
 		t.Fatalf("Get of %s after delete unexpectedly succeeded", netKey1)

--- a/subnet/registry.go
+++ b/subnet/registry.go
@@ -116,7 +116,7 @@ func newEtcdSubnetRegistry(config *EtcdConfig, cliNewFunc etcdNewFunc) (Registry
 
 func (esr *etcdSubnetRegistry) getNetworkConfig(ctx context.Context, network string) (string, error) {
 	key := path.Join(esr.etcdCfg.Prefix, network, "config")
-	resp, err := esr.client().Get(ctx, key, nil)
+	resp, err := esr.client().Get(ctx, key, &etcd.GetOptions{Quorum: true})
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +128,7 @@ func (esr *etcdSubnetRegistry) getNetworkConfig(ctx context.Context, network str
 // point for etcd watch.
 func (esr *etcdSubnetRegistry) getSubnets(ctx context.Context, network string) ([]Lease, uint64, error) {
 	key := path.Join(esr.etcdCfg.Prefix, network, "subnets")
-	resp, err := esr.client().Get(ctx, key, &etcd.GetOptions{Recursive: true})
+	resp, err := esr.client().Get(ctx, key, &etcd.GetOptions{Recursive: true, Quorum: true})
 	if err != nil {
 		if etcdErr, ok := err.(etcd.Error); ok && etcdErr.Code == etcd.ErrorCodeKeyNotFound {
 			// key not found: treat it as empty set
@@ -153,7 +153,7 @@ func (esr *etcdSubnetRegistry) getSubnets(ctx context.Context, network string) (
 
 func (esr *etcdSubnetRegistry) getSubnet(ctx context.Context, network string, sn ip.IP4Net) (*Lease, uint64, error) {
 	key := path.Join(esr.etcdCfg.Prefix, network, "subnets", MakeSubnetKey(sn))
-	resp, err := esr.client().Get(ctx, key, nil)
+	resp, err := esr.client().Get(ctx, key, &etcd.GetOptions{Quorum: true})
 	if err != nil {
 		return nil, 0, err
 	}
@@ -250,7 +250,7 @@ func (esr *etcdSubnetRegistry) watchSubnet(ctx context.Context, network string, 
 // networks along with the 'as-of' etcd-index that can be used as the starting
 // point for etcd watch.
 func (esr *etcdSubnetRegistry) getNetworks(ctx context.Context) ([]string, uint64, error) {
-	resp, err := esr.client().Get(ctx, esr.etcdCfg.Prefix, &etcd.GetOptions{Recursive: true})
+	resp, err := esr.client().Get(ctx, esr.etcdCfg.Prefix, &etcd.GetOptions{Recursive: true, Quorum: true})
 
 	networks := []string{}
 


### PR DESCRIPTION
To avoid odd situation of flannel not reusing last lease
upon restart, flannel should use quorum=true when reading
from etcd to get linearizability.

Fix #383