### PR TITLE
The docker daemon syntax change addressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Since flannel writes out the acquired subnet and MTU values into a file, the scr
 
 ```bash
 source /run/flannel/subnet.env
-docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU}
+docker daemon --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} &
 ```
 
 Systemd users can use `EnvironmentFile` directive in the .service file to pull in `/run/flannel/subnet.env`


### PR DESCRIPTION
On current docker version the command in docs doesn't run.

Original: https://xelatex.github.io/2015/10/10/Flannel-for-Docker-Overlay-Network/