### PR TITLE
Updated deprecated google/golang docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you would like to build inside a Docker container but to produce a binary on 
 
 ```
 # Replace $SRC with the absolute path to your flannel source code
-docker run -v $SRC:/opt/flannel -i -t google/golang /bin/bash -c "cd /opt/flannel && ./build"
+docker run -v $SRC:/opt/flannel -i -t golang:1.6 /bin/bash -c "cd /opt/flannel && ./build"
 ```
 
 ## Configuration


### PR DESCRIPTION
google/golang on dockerhub has been deprecated: https://hub.docker.com/r/google/golang/

The new official GO address is here: https://hub.docker.com/_/golang/

The flannel build fails unless it's run with modern versions of GO which is only supported in the second link