### PR TITLE
backend: do not log in Register

### DIFF
--- a/backend/manager.go
+++ b/backend/manager.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/golang/glog"
 	"golang.org/x/net/context"
 
 	"github.com/coreos/flannel/subnet"
@@ -96,6 +95,5 @@ func (bm *manager) Wait() {
 }
 
 func Register(name string, ctor BackendCtor) {
-	log.Infof("Register: %v", name)
 	backendCtors[name] = ctor
 }


### PR DESCRIPTION
various backends call backend.Register, which will log a message.
because Register is called in init() functions before main() runs,
glog's 'logtostderr' flag is not set yet, so glog attemps to create log
files in $TMPDIR. this directory doesn't exist in the new busybox base
image, and we don't want to write log files anyway.