### PR TITLE
Fix the kube-flannel.yaml in order to work

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -40,9 +40,11 @@ spec:
         app: flannel
     spec:
       hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel-git:latest
+        image: quay.io/coreos/flannel-git:v0.6.1-28-g5dde68d-amd64
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true
@@ -61,8 +63,8 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: busybox
-        command: [ "/bin/sh", "-c", "set -e -x; TMP=/etc/cni/net.d/.tmp-flannel-cfg; cp /etc/kube-flannel/cni-conf.json ${TMP}; mv ${TMP} /etc/cni/net.d/10-flannel.conf; while :; do sleep 3600; done" ]
+        image: quay.io/coreos/flannel-git:v0.6.1-28-g5dde68d-amd64
+        command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d


### PR DESCRIPTION
@tomdee This makes it possible to run this flannel daemonset on other architectures as well, thanks!
Just `curl -sSL <url> | sed "s/amd64/arm/" | kubectl apply -f -` and you're done!

Can you merge this please so we can use it with kubeadm please?