### PR TITLE
Fixed #521: flanneld hang on at initialEvtsBatch := <-evts because of…

### DIFF
--- a/backend/vxlan/network.go
+++ b/backend/vxlan/network.go
@@ -73,14 +73,20 @@ func (n *network) Run(ctx context.Context) {
 	}()
 
 	defer wg.Wait()
-	initialEvtsBatch := <-evts
-	for {
-		err := n.handleInitialSubnetEvents(initialEvtsBatch)
-		if err == nil {
-			break
+
+	select {
+	case initialEvtsBatch := <-evts:
+		for {
+			err := n.handleInitialSubnetEvents(initialEvtsBatch)
+			if err == nil {
+				break
+			}
+			log.Error(err, " About to retry")
+			time.Sleep(time.Second)
 		}
-		log.Error(err, " About to retry")
-		time.Sleep(time.Second)
+
+	case <-ctx.Done():
+		return
 	}
 
 	for {


### PR DESCRIPTION
Now it will add subnet again into etcd, and never block at `initialEvtsBatch := <-evts `:
```
I0928 17:49:39.598809   11424 main.go:132] Installing signal handlers
I0928 17:49:39.600694   11424 manager.go:163] Using 10.0.2.15 as external interface
I0928 17:49:39.601543   11424 manager.go:164] Using 10.0.2.15 as external endpoint
I0928 17:49:40.034193   11424 local_manager.go:179] Picking subnet in range 192.168.65.0 ... 192.168.79.0
I0928 17:49:40.070585   11424 ipmasq.go:47] Adding iptables rule: -s 192.168.64.0/20 -d 192.168.64.0/20 -j RETURN
I0928 17:49:40.071953   11424 ipmasq.go:47] Adding iptables rule: -s 192.168.64.0/20 ! -d 224.0.0.0/4 -j MASQUERADE
I0928 17:49:40.073654   11424 ipmasq.go:47] Adding iptables rule: ! -s 192.168.64.0/20 -d 192.168.64.0/20 -j MASQUERADE
I0928 17:49:40.075106   11424 manager.go:246] Lease acquired: 192.168.67.0/24
I0928 17:49:40.075748   11424 network.go:58] Watching for L3 misses
I0928 17:49:40.076684   11424 network.go:66] Watching for new subnet leases
I0928 17:49:40.315828   11424 watch.go:38] sm.WatchLeases: {[] [{192.168.67.0/24 {10.0.2.15 vxlan [123 34 86 116 101 112 77 65 67 34 58 34 57 101 58 97 97 58 97 55 58 97 52 58 49 54 58 57 99 34 125]} 2016-09-28 09:52:42.79400663 +0000 UTC 3605}] 3605} <nil>
I0928 17:49:40.317309   11424 watch.go:53] res.Events: []
I0928 17:49:40.317671   11424 watch.go:54] res.Snapshot: [{192.168.67.0/24 {10.0.2.15 vxlan [123 34 86 116 101 112 77 65 67 34 58 34 57 101 58 97 97 58 97 55 58 97 52 58 49 54 58 57 99 34 125]} 2016-09-28 09:52:42.79400663 +0000 UTC 3605}]
I0928 17:49:40.317972   11424 watch.go:63] in lw.reset, batch: []
I0928 17:49:40.318272   11424 watch.go:66] batch: []
E0928 17:51:43.796668   11424 network.go:160] Error renewing lease (trying again in 1 min): client: etcd cluster is unavailable or misconfigured
E0928 17:52:44.800409   11424 network.go:160] Error renewing lease (trying again in 1 min): client: etcd cluster is unavailable or misconfigured
E0928 17:53:45.802062   11424 network.go:160] Error renewing lease (trying again in 1 min): client: etcd cluster is unavailable or misconfigured
E0928 17:54:46.804301   11424 network.go:160] Error renewing lease (trying again in 1 min): client: etcd cluster is unavailable or misconfigured
W0928 17:54:51.513443   11424 network.go:175] Lease has been revoked
I0928 17:54:51.513992   11424 network.go:71] WatchLeases exited
I0928 17:54:51.521338   11424 ipmasq.go:64] Deleting iptables rule: -s 192.168.64.0/20 -d 192.168.64.0/20 -j RETURN
I0928 17:54:51.527282   11424 ipmasq.go:64] Deleting iptables rule: -s 192.168.64.0/20 ! -d 224.0.0.0/4 -j MASQUERADE
I0928 17:54:51.530937   11424 ipmasq.go:64] Deleting iptables rule: ! -s 192.168.64.0/20 -d 192.168.64.0/20 -j MASQUERADE
I0928 17:54:51.652465   11424 local_manager.go:179] Picking subnet in range 192.168.65.0 ... 192.168.79.0
I0928 17:54:51.702858   11424 ipmasq.go:47] Adding iptables rule: -s 192.168.64.0/20 -d 192.168.64.0/20 -j RETURN
I0928 17:54:51.708384   11424 ipmasq.go:47] Adding iptables rule: -s 192.168.64.0/20 ! -d 224.0.0.0/4 -j MASQUERADE
I0928 17:54:51.712628   11424 ipmasq.go:47] Adding iptables rule: ! -s 192.168.64.0/20 -d 192.168.64.0/20 -j MASQUERADE
I0928 17:54:51.717082   11424 manager.go:246] Lease acquired: 192.168.68.0/24
I0928 17:54:51.720782   11424 network.go:58] Watching for L3 misses
I0928 17:54:51.720963   11424 network.go:66] Watching for new subnet leases
I0928 17:54:51.777164   11424 watch.go:38] sm.WatchLeases: {[] [{192.168.68.0/24 {10.0.2.15 vxlan [123 34 86 116 101 112 77 65 67 34 58 34 57 101 58 97 97 58 97 55 58 97 52 58 49 54 58 57 99 34 125]} 2016-09-28 09:57:54.426360683 +0000 UTC 3607}] 3607} <nil>
I0928 17:54:51.777825   11424 watch.go:53] res.Events: []
I0928 17:54:51.777974   11424 watch.go:54] res.Snapshot: [{192.168.68.0/24 {10.0.2.15 vxlan [123 34 86 116 101 112 77 65 67 34 58 34 57 101 58 97 97 58 97 55 58 97 52 58 49 54 58 57 99 34 125]} 2016-09-28 09:57:54.426360683 +0000 UTC 3607}]
I0928 17:54:51.778156   11424 watch.go:63] in lw.reset, batch: []
I0928 17:54:51.778385   11424 watch.go:66] batch: []
I0928 17:56:55.224667   11424 watch.go:38] sm.WatchLeases: {[{0 {192.168.68.0/24 {10.0.2.15 vxlan [123 34 86 116 101 112 77 65 67 34 58 34 57 101 58 97 97 58 97 55 58 97 52 58 49 54 58 57 99 34 125]} 2016-09-28 09:59:57.933059168 +0000 UTC 0} }] [] 3608} <nil>
I0928 17:56:55.224794   11424 watch.go:53] res.Events: [{0 {192.168.68.0/24 {10.0.2.15 vxlan [123 34 86 116 101 112 77 65 67 34 58 34 57 101 58 97 97 58 97 55 58 97 52 58 49 54 58 57 99 34 125]} 2016-09-28 09:59:57.933059168 +0000 UTC 0} }]
I0928 17:56:55.224827   11424 watch.go:54] res.Snapshot: []
I0928 17:56:55.224837   11424 watch.go:60] in lw.update, batch: []
I0928 17:56:55.224845   11424 watch.go:66] batch: []
I0928 17:56:55.225002   11424 network.go:165] Lease renewed, new expiration: 2016-09-28 09:59:57.933059168 +0000 UTC
```