### PR TITLE
aws-vpc: Fix crash when route has vpc-endpoints

### DIFF
--- a/backend/awsvpc/awsvpc.go
+++ b/backend/awsvpc/awsvpc.go
@@ -154,7 +154,7 @@ func (be *AwsVpcBackend) checkMatchingRoutes(routeTableID, instanceID, subnet st
 
 	for _, routeTable := range resp.RouteTables {
 		for _, route := range routeTable.Routes {
-			if subnet == *route.DestinationCidrBlock && *route.State == "active" {
+			if route.DestinationCidrBlock != nil && subnet == *route.DestinationCidrBlock && *route.State == "active" {
 
 				if *route.InstanceId == instanceID {
 					matchingRouteFound = true


### PR DESCRIPTION
This fixes aws-vpc when the route table has [vcp-endpoints](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-endpoints.html)

### Crashlog for version in master
```
I1002 09:31:59.577237    5056 main.go:132] Installing signal handlers
I1002 09:31:59.577499    5056 manager.go:133] Determining IP address of default interface
I1002 09:31:59.577828    5056 manager.go:163] Using 10.0.1.173 as external interface
I1002 09:31:59.577899    5056 manager.go:164] Using 10.0.1.173 as external endpoint
I1002 09:31:59.690117    5056 local_manager.go:134] Found lease (10.5.30.0/24) for current IP (10.0.1.173), reusing
I1002 09:31:59.693114    5056 local_manager.go:134] Found lease (10.6.105.0/24) for current IP (10.0.1.173), reusing
I1002 09:31:59.987196    5056 awsvpc.go:100] RouteTableID not passed as config parameter, detecting ...
I1002 09:31:59.992134    5056 awsvpc.go:100] RouteTableID not passed as config parameter, detecting ...
I1002 09:32:00.146252    5056 awsvpc.go:212] Subnet-ID: subnet-9896b3ef
I1002 09:32:00.146429    5056 awsvpc.go:213] VPC-ID: vpc-240eee41
I1002 09:32:00.164322    5056 awsvpc.go:212] Subnet-ID: subnet-9896b3ef
I1002 09:32:00.164457    5056 awsvpc.go:213] VPC-ID: vpc-240eee41
I1002 09:32:00.298229    5056 awsvpc.go:106] RouteRouteTableID: rtb-3f937c5a
I1002 09:32:00.301051    5056 awsvpc.go:106] RouteRouteTableID: rtb-3f937c5a
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x4dbe80]

goroutine 19 [running]:
panic(0x1b46e20, 0xc8200100b0)
	/usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/coreos/flannel/backend/awsvpc.(*AwsVpcBackend).checkMatchingRoutes(0xc820468a80, 0xc8205062f0, 0xc, 0xc820468700, 0x13, 0xc8204dc640, 0xc, 0xc8200260d0, 0x0, 0x0, ...)
	/go/src/github.com/coreos/flannel/backend/awsvpc/awsvpc.go:157 +0x740
github.com/coreos/flannel/backend/awsvpc.(*AwsVpcBackend).RegisterNetwork(0xc820468a80, 0x7fa0bb8defc8, 0xc8204136c0, 0xc820441c14, 0x3, 0xc8203e0d20, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/coreos/flannel/backend/awsvpc/awsvpc.go:108 +0xb0e
github.com/coreos/flannel/network.(*Network).init(0xc82043ff80, 0x0, 0x0)
	/go/src/github.com/coreos/flannel/network/network.go:84 +0x235
github.com/coreos/flannel/network.(*Network).retryInit(0xc82043ff80, 0x0, 0x0)
	/go/src/github.com/coreos/flannel/network/network.go:101 +0x4d
github.com/coreos/flannel/network.(*Network).runOnce(0xc82043ff80, 0xc820412f80, 0xc820637f30, 0x0, 0x0)
	/go/src/github.com/coreos/flannel/network/network.go:117 +0x68
github.com/coreos/flannel/network.(*Network).Run(0xc82043ff80, 0xc820412f80, 0xc820637f30)
	/go/src/github.com/coreos/flannel/network/network.go:185 +0x39
github.com/coreos/flannel/network.(*Manager).runNetwork(0xc82042ea20, 0xc82043ff80)
	/go/src/github.com/coreos/flannel/network/manager.go:254 +0x4b
github.com/coreos/flannel/network.(*Manager).Run.func1.1(0xc82042ea20, 0xc820448880, 0xc82043ff80)
	/go/src/github.com/coreos/flannel/network/manager.go:348 +0x2b
created by github.com/coreos/flannel/network.(*Manager).Run.func1
	/go/src/github.com/coreos/flannel/network/manager.go:350 +0x6d
```

### Analysis

When the route table has `vpc-enpoints` `DescribeRouteTables` call returns the following structure:
```
  RouteTables: [{
      Associations: [...],
      RouteTableId: "rtb-3f937c5a",
      Routes: [
        {
          DestinationCidrBlock: "10.5.30.0/24",
          NetworkInterfaceId: "eni-5585b519",
          Origin: "CreateRoute",
          State: "blackhole"
        },
        {
          DestinationCidrBlock: "10.5.94.0/24",
          InstanceId: "i-08346ee7b1d9b7808",
          InstanceOwnerId: "887104083023",
          NetworkInterfaceId: "eni-8ea9c8c2",
          Origin: "CreateRoute",
          State: "active"
        },
...
        {
          DestinationCidrBlock: "0.0.0.0/0",
          GatewayId: "igw-3cf6e95e",
          Origin: "CreateRoute",
          State: "active"
        },
        {
          DestinationPrefixListId: "pl-6da54004",
          GatewayId: "vpce-68bd5b01",
          Origin: "CreateRoute",
          State: "active"
        }
      ],
      Tags: [...]
```

One of the routes has no `DestinationCidrBlock` entry, but `DestinationPrefixListId` instead.
