### PR TITLE
Add a flag to configure the subnet lease renewal margin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ This is the only mandatory key.
    The list of available backends and the keys that can be put into the this dictionary are listed below.
    Defaults to "udp" backend.
 
+The lease on a subnet is hard-coded to 24h (see [`subnetTTL`](subnet/local_manager.go#L31)).
+Subnet lease are renewed within 1h of their expiration (can be overridden via `--subnet-lease-renew-margin`).
+
 ### Backends
 * udp: use UDP to encapsulate the packets.
   * `Type` (string): `udp`
@@ -178,6 +181,7 @@ $ flanneld --remote=10.0.0.3:8888 --networks=blue,green
 --etcd-cafile="": SSL Certificate Authority file used to secure etcd communication.
 --iface="": interface to use (IP or name) for inter-host communication. Defaults to the interface for the default route on the machine.
 --subnet-file=/run/flannel/subnet.env: filename where env variables (subnet and MTU values) will be written to.
+--subnet-lease-renew-margin=60: subnet lease renewal margin, in minutes.
 --ip-masq=false: setup IP masquerade for traffic destined for outside the flannel network. Flannel assumes that the default policy is ACCEPT in the NAT POSTROUTING chain.
 --listen="": if specified, will run in server mode. Value is IP and port (e.g. `0.0.0.0:8888`) to listen on or `fd://` for [socket activation](http://www.freedesktop.org/software/systemd/man/systemd.socket.html).
 --remote="": if specified, will run in client mode. Value is IP and port of the server.

--- a/network/manager.go
+++ b/network/manager.go
@@ -36,13 +36,14 @@ import (
 )
 
 type CmdLineOpts struct {
-	publicIP      string
-	ipMasq        bool
-	subnetFile    string
-	subnetDir     string
-	iface         string
-	networks      string
-	watchNetworks bool
+	publicIP               string
+	ipMasq                 bool
+	subnetFile             string
+	subnetDir              string
+	iface                  string
+	networks               string
+	watchNetworks          bool
+	subnetLeaseRenewMargin int
 }
 
 var errAlreadyExists = errors.New("already exists")
@@ -55,6 +56,7 @@ func init() {
 	flag.StringVar(&opts.subnetDir, "subnet-dir", "/run/flannel/networks", "directory where files with env variables (subnet, MTU, ...) will be written to")
 	flag.StringVar(&opts.iface, "iface", "", "interface to use (IP or name) for inter-host communication")
 	flag.StringVar(&opts.networks, "networks", "", "run in multi-network mode and service the specified networks")
+	flag.IntVar(&opts.subnetLeaseRenewMargin, "subnet-lease-renew-margin", 60, "Subnet lease renewal margin, in minutes.")
 	flag.BoolVar(&opts.watchNetworks, "watch-networks", false, "run in multi-network mode and watch for networks from 'networks' or all networks")
 	flag.BoolVar(&opts.ipMasq, "ip-masq", false, "setup IP masquerade rule for traffic destined outside of overlay network")
 }

--- a/network/network.go
+++ b/network/network.go
@@ -27,10 +27,6 @@ import (
 	"github.com/coreos/flannel/subnet"
 )
 
-const (
-	renewMargin = time.Hour
-)
-
 var (
 	errInterrupted = errors.New("interrupted")
 	errCanceled    = errors.New("canceled")
@@ -147,6 +143,8 @@ func (n *Network) runOnce(extIface *backend.ExternalInterface, inited func(bn ba
 	}()
 
 	defer wg.Wait()
+
+	renewMargin := time.Duration(opts.subnetLeaseRenewMargin) * time.Minute
 
 	dur := n.bn.Lease().Expiration.Sub(time.Now()) - renewMargin
 	for {


### PR DESCRIPTION
This adds the command-line flag `--subnet-lease-renew-margin`, specified as
a number of minutes, instead of relying on the hard-coded default of 1h.