### PR TITLE
[do-not-merge] backend/vxlan: Remove local broadcast route for network

### DIFF
--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -28,6 +28,8 @@ import (
 	"github.com/coreos/flannel/pkg/ip"
 )
 
+const RTN_BROADCAST = 3
+
 type vxlanDeviceAttrs struct {
 	vni       uint32
 	name      string
@@ -126,6 +128,30 @@ func (dev *vxlanDevice) Configure(ipn ip.IP4Net) error {
 
 	if err := netlink.LinkSetUp(dev.link); err != nil {
 		return fmt.Errorf("failed to set interface %s to UP state: %s", dev.link.Attrs().Name, err)
+	}
+
+	// Drop the local route table entry for broadcast to the flannel network address
+	// See: https://github.com/coreos/flannel/issues/533
+	broadcastFilter := &netlink.Route{
+		LinkIndex: dev.link.Attrs().Index,
+		Table:     syscall.RT_TABLE_LOCAL,
+		Type:      RTN_BROADCAST,
+	}
+
+	filterMask := netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_TYPE
+	filterRoutes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, broadcastFilter, filterMask)
+	if err != nil {
+		return fmt.Errorf("Failed to list routes: %v", err)
+	}
+
+	for _, r := range filterRoutes {
+		// Remove broadcast route for network address
+		if r.Dst.IP.Equal(ipn.Network().ToIPNet().IP) {
+			log.Infof("Removing broadcast route: %s", r.String())
+			if err := netlink.RouteDel(&r); err != nil {
+				return fmt.Errorf("Failed to delete route: %v", err)
+			}
+		}
 	}
 
 	// explicitly add a route since there might be a route for a subnet already


### PR DESCRIPTION
Fixes https://github.com/coreos/flannel/issues/533
Fixes https://github.com/coreos/flannel/issues/535

This change will remove the broadcast route added to the local route table when the vxlan interface is setup. By removing the route entry, the node will be able to properly route traffic meant for the host assigned the network address within the in flannel network (see issue/533 for more info).

While this may seem a bit heavy-handed - if flannel is restarted, the broadcast routes will not be re-created anyway.

/cc @tomdee @philips 