### PR TITLE
e2e: Allow the backend list to be overridden

### DIFF
--- a/dist/functional-test.sh
+++ b/dist/functional-test.sh
@@ -126,8 +126,7 @@ echo etcd launched
 
 global_exit_code=0
 
-backends="udp vxlan host-gw"
-
+backends=${BACKEND:-"udp vxlan host-gw"} 
 for backend in $backends; do
 	echo
 	echo "=== BACKEND: $backend ==============================================="


### PR DESCRIPTION
e.g.
BACKEND=vxlan make e2e-test

to run just the vxlan tests