### PR TITLE
Update kube-flannel.yaml

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -44,7 +44,7 @@ spec:
         beta.kubernetes.io/arch: amd64
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel-git:v0.6.1-28-g5dde68d-amd64
+        image: quay.io/coreos/flannel-git:v0.6.1-62-g6d631ba-amd64
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: quay.io/coreos/flannel-git:v0.6.1-28-g5dde68d-amd64
+        image: quay.io/coreos/flannel-git:v0.6.1-62-g6d631ba-amd64
         command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
         volumeMounts:
         - name: cni


### PR DESCRIPTION
Updates the kube-flannel.yaml file to incorporate https://github.com/coreos/flannel/pull/564

@aaronlevy Please merge this today, it's making flannel work more reliably with kubeadm 
(Also I have a blog post that depends on it)