### PR TITLE
[doc][kube-flannel] set explicit arch on daemonset images

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: flannel
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.7.0
+        image: quay.io/coreos/flannel:v0.7.0-amd64
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true
@@ -67,7 +67,7 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.7.0
+        image: quay.io/coreos/flannel:v0.7.0-amd64
         command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
         volumeMounts:
         - name: cni


### PR DESCRIPTION
It would help for quick scripting on dev/test environments and other architectures.

For instance the [following instructions](https://github.com/luxas/kubernetes-on-arm#set-up-the-master) are currently broken since https://github.com/coreos/flannel/commit/ee52b531b0c3ce81b3a08bc3a5dccf4d31476ecd.