### PR TITLE
Tolerate flannel running on master nodes

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -45,6 +45,9 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: flannel
       containers:
       - name: kube-flannel


### PR DESCRIPTION
DaemonSets now respect taints. This PR adds a tolerance that allows flannel to run nodes tainted with `dedicated=master:NoSchedule`