### PR TITLE
backend/vxlan: Don't recreate vxlan device on flanneld restart

### DIFF
--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -294,24 +294,14 @@ func vxlanLinksIncompat(l1, l2 netlink.Link) string {
 	return ""
 }
 
-// sets IP4 addr on link removing any existing ones first
+// sets IP4 addr on link
 func setAddr4(link *netlink.Vxlan, ipn *net.IPNet) error {
-	addrs, err := netlink.AddrList(link, syscall.AF_INET)
-	if err != nil {
-		return err
-	}
-
-	for _, addr := range addrs {
-		if err = netlink.AddrDel(link, &addr); err != nil {
-			return fmt.Errorf("failed to delete IPv4 addr %s from %s", addr.String(), link.Attrs().Name)
-		}
-	}
 	// Ensure that the device has a /32 address so that no broadcast routes are created.
 	// This IP is just used as a source address for host to workload traffic (so
 	// the return path for the traffic has a decent address to use as the destination)
 	ipn.Mask = net.CIDRMask(32, 32)
 	addr := netlink.Addr{IPNet: ipn, Label: ""}
-	if err = netlink.AddrAdd(link, &addr); err != nil {
+	if err := netlink.AddrAdd(link, &addr); err != nil {
 		return fmt.Errorf("failed to add IP address %s to %s: %s", ipn.String(), link.Attrs().Name, err)
 	}
 


### PR DESCRIPTION
Stop deleting IP addresses from the vxlan device, there's no need to do
it and it disrupts traffic during daemon restart.