### PR TITLE
Makefile: Use $(CURDIR)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ dist/flanneld-$(ARCH):
 	# valid values for $$ARCH are [amd64 arm arm64 ppc64le]
 	docker run -e CC=$(CC) -e GOARM=$(GOARM) -e GOARCH=$(ARCH) \
 		-u $(shell id -u):$(shell id -g) \
-	    -v ${PWD}:/go/src/github.com/coreos/flannel:ro \
-        -v ${PWD}/dist:/go/src/github.com/coreos/flannel/dist \
+	    -v $(CURDIR):/go/src/github.com/coreos/flannel:ro \
+        -v $(CURDIR)/dist:/go/src/github.com/coreos/flannel/dist \
 	    gcr.io/google_containers/kube-cross:$(KUBE_CROSS_TAG) /bin/bash -c '\
 		cd /go/src/github.com/coreos/flannel && \
 		CGO_ENABLED=1 make -e dist/flanneld && \
@@ -116,8 +116,8 @@ dist/libpthread.so.0-$(ARCH):
 dist/iptables-$(ARCH):
 	docker run -e CC=$(CC) -e GOARM=$(GOARM) -e GOARCH=$(ARCH) \
 			-u $(shell id -u):$(shell id -g) \
-            -v ${PWD}:/go/src/github.com/coreos/flannel:ro \
-            -v ${PWD}/dist:/go/src/github.com/coreos/flannel/dist \
+            -v $(CURDIR):/go/src/github.com/coreos/flannel:ro \
+            -v $(CURDIR)/dist:/go/src/github.com/coreos/flannel/dist \
             gcr.io/google_containers/kube-cross:$(KUBE_CROSS_TAG) /bin/bash -c '\
             curl -sSL http://www.netfilter.org/projects/iptables/files/iptables-$(IPTABLES_VERSION).tar.bz2 | tar -jxv && \
             cd iptables-$(IPTABLES_VERSION) && \


### PR DESCRIPTION
The current makefile variable 'PWD' is not defined in the makefile,
and leads to build errors.  Use $(shell pwd) instead.

Fixes errors like these:

  docker: Error response from daemon: Invalid volume spec ":/go/src/github.com/coreos/flannel:ro"
