### PR TITLE
Explicit operator: Exists to allow toleration on masters

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -50,6 +50,7 @@ spec:
         beta.kubernetes.io/arch: amd64
       tolerations:
       - key: node-role.kubernetes.io/master
+        operator: Exists
         effect: NoSchedule
       serviceAccountName: flannel
       containers:


### PR DESCRIPTION
The operator field default to Equals.
We want to schedule flannel to any nodes with node-role.kubernetes.io/master taint regardless of what value was set (which will usually be 'true').
Adding this line allows the DS to schedule flannel pods to master nodes.