### PR TITLE
Makefile: Switch to a new version of kube-cross

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ dist/*.tar.gz
 dist/flanneld*
 dist/iptables-*
 dist/libpthread*
+dist/ld64*
+dist/libc*
 dist/*.aci
 dist/*.docker
 cover.out

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,10 +1,12 @@
-FROM busybox:1.25.0-glibc
+FROM frolvlad/alpine-glibc
 
 MAINTAINER Tom Denham <tom@tigera.io>
 
-COPY dist/flanneld-amd64 /opt/bin/flanneld
-COPY dist/iptables-amd64 /usr/local/bin/iptables
+ENV FLANNEL_ARCH=amd64
+
+COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
+COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
 COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-amd64 /lib/libpthread.so.0
+
 CMD ["/opt/bin/flanneld"]
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -2,8 +2,14 @@ FROM armel/busybox:glibc
 
 MAINTAINER Tom Denham <tom@tigera.io>
 
-COPY dist/flanneld-arm /opt/bin/flanneld
-COPY dist/iptables-arm /usr/local/bin/iptables
+ENV FLANNEL_ARCH=arm
+
+COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
+COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
 COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-arm /lib/libpthread.so.0
+COPY dist/libpthread.so.0-$FLANNEL_ARCH /lib/libpthread.so.0
+COPY dist/ld64.so.1-$FLANNEL_ARCH /lib/ld64.so.1
+COPY dist/libc.so.6-$FLANNEL_ARCH /lib/libc.so.6
+
+
 CMD ["/opt/bin/flanneld"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -2,9 +2,11 @@ FROM aarch64/busybox:glibc
 
 MAINTAINER Tom Denham <tom@tigera.io>
 
-COPY dist/flanneld-arm64 /opt/bin/flanneld
-COPY dist/iptables-arm64 /usr/local/bin/iptables
-COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-arm64 /lib/libpthread.so.0
-CMD ["/opt/bin/flanneld"]
+ENV FLANNEL_ARCH=arm64
 
+COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
+COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
+COPY dist/mk-docker-opts.sh /opt/bin/
+COPY dist/libpthread.so.0-$FLANNEL_ARCH /lib/libpthread.so.0
+COPY dist/ld64.so.1-$FLANNEL_ARCH /lib/ld64.so.1
+COPY dist/libc.so.6-$FLANNEL_ARCH /lib/libc.so.6

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -2,9 +2,11 @@ FROM ppc64le/busybox:glibc
 
 MAINTAINER Tom Denham <tom@tigera.io>
 
-COPY dist/flanneld-ppc64le /opt/bin/flanneld
-COPY dist/iptables-ppc64le /usr/local/bin/iptables
-COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-ppc64le /lib/libpthread.so.0
-CMD ["/opt/bin/flanneld"]
+ENV FLANNEL_ARCH=ppc64le
 
+COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
+COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
+COPY dist/mk-docker-opts.sh /opt/bin/
+COPY dist/libpthread.so.0-$FLANNEL_ARCH /lib/libpthread.so.0
+COPY dist/ld64.so.1-$FLANNEL_ARCH /lib/ld64.so.1
+COPY dist/libc.so.6-$FLANNEL_ARCH /lib/libc.so.6

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -2,10 +2,13 @@ FROM s390x/busybox:glibc
 
 MAINTAINER Tom Denham <tom@tigera.io>
 
-COPY dist/flanneld-s390x /opt/bin/flanneld
-COPY dist/iptables-s390x /usr/local/bin/iptables
+ENV FLANNEL_ARCH=s390x
+
+COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
+COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
 COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-s390x /lib/libpthread.so.0
-COPY dist/ld64.so.1 /lib/ld64.so.1
-COPY dist/libc.so.6 /lib/libc.so.6
+COPY dist/libpthread.so.0-$FLANNEL_ARCH /lib/libpthread.so.0
+COPY dist/ld64.so.1-$FLANNEL_ARCH /lib/ld64.so.1
+COPY dist/libc.so.6-$FLANNEL_ARCH /lib/libc.so.6
+
 CMD ["/opt/bin/flanneld"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,0 +1,11 @@
+FROM s390x/busybox:glibc
+
+MAINTAINER Tom Denham <tom@tigera.io>
+
+COPY dist/flanneld-s390x /opt/bin/flanneld
+COPY dist/iptables-s390x /usr/local/bin/iptables
+COPY dist/mk-docker-opts.sh /opt/bin/
+COPY dist/libpthread.so.0-s390x /lib/libpthread.so.0
+COPY dist/ld64.so.1 /lib/ld64.so.1
+COPY dist/libc.so.6 /lib/libc.so.6
+CMD ["/opt/bin/flanneld"]

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,17 @@ ifeq ($(ARCH),ppc64le)
 	LIB_DIR=powerpc64le-linux-gnu
 	CC=powerpc64le-linux-gnu-gcc
 endif
+ifeq ($(ARCH),s390x)
+	LIB_DIR=s390x-linux-gnu
+	CC=s390x-linux-gnu-gcc
+endif
 GOARM=6
-KUBE_CROSS_TAG=v1.6.2-2
+ifeq ($(ARCH),s390x)
+	# kube-cross:v1.7.4-1 supports s390x
+	KUBE_CROSS_TAG=v1.7.4-1
+else
+	KUBE_CROSS_TAG=v1.6.2-2
+endif
 IPTABLES_VERSION=1.4.21
 
 dist/flanneld: $(shell find . -type f  -name '*.go')
@@ -97,7 +106,7 @@ endif
 ## Build an architecture specific flanneld binary
 dist/flanneld-$(ARCH):
 	# Build for other platforms with 'ARCH=$$ARCH make dist/flanneld-$$ARCH'
-	# valid values for $$ARCH are [amd64 arm arm64 ppc64le]
+	# valid values for $$ARCH are [amd64 arm arm64 ppc64le s390x]
 	docker run -e CC=$(CC) -e GOARM=$(GOARM) -e GOARCH=$(ARCH) \
 		-u $(shell id -u):$(shell id -g) \
 	    -v $(CURDIR):/go/src/github.com/coreos/flannel:ro \
@@ -110,7 +119,14 @@ dist/flanneld-$(ARCH):
 
 ## Busybox images are missing pthread. Pull it out of the kube-cross image
 dist/libpthread.so.0-$(ARCH):
+ifeq ($(ARCH),s390x)
+	# Busybox images are having older version of libc.so.6 and ld64.so.1. Pull it out of the kube-cross image
+	docker run --rm -v `pwd`:/host gcr.io/google_containers/kube-cross:$(KUBE_CROSS_TAG) cp /usr/$(LIB_DIR)/lib/libpthread.so.0 /host/dist/libpthread.so.0-$(ARCH)
+	docker run --rm -v `pwd`:/host gcr.io/google_containers/kube-cross:$(KUBE_CROSS_TAG) cp /usr/$(LIB_DIR)/lib/libc-2.23.so /host/dist/libc.so.6
+	docker run --rm -v `pwd`:/host gcr.io/google_containers/kube-cross:$(KUBE_CROSS_TAG) cp /usr/$(LIB_DIR)/lib/ld-2.23.so /host/dist/ld64.so.1
+else
 	docker run --rm -v `pwd`:/host gcr.io/google_containers/kube-cross:$(KUBE_CROSS_TAG) cp /lib/$(LIB_DIR)/libpthread.so.0 /host/dist/libpthread.so.0-$(ARCH)
+endif
 
 ## Build an architecture specific iptables binary
 dist/iptables-$(ARCH):
@@ -148,6 +164,9 @@ tar.gz:
 	ARCH=arm64 make dist/flanneld-arm64
 	tar --transform='flags=r;s|-arm64||' -zcvf dist/flannel-$(TAG)-linux-arm64.tar.gz -C dist flanneld-arm64 mk-docker-opts.sh ../README.md
 	tar -tvf dist/flannel-$(TAG)-linux-arm64.tar.gz
+	ARCH=s390x make dist/flanneld-s390x
+	tar --transform='flags=r;s|-s390x||' -zcvf dist/flannel-$(TAG)-linux-s390x.tar.gz -C dist flanneld-s390x mk-docker-opts.sh ../README.md
+	tar -tvf dist/flannel-$(TAG)-linux-s390x.tar.gz
 
 ## Make a release after creating a tag
 release: tar.gz
@@ -155,6 +174,7 @@ release: tar.gz
 	ARCH=arm make dist/flanneld-$(TAG)-arm.aci
 	ARCH=arm64 make dist/flanneld-$(TAG)-arm64.aci
 	ARCH=ppc64le make dist/flanneld-$(TAG)-ppc64le.aci
+	ARCH=s390x make dist/flanneld-$(TAG)-s390x.aci
 	@echo "Everything should be built for $(TAG)"
 	@echo "Add all *.aci, flanneld-* and *.tar.gz files from dist/ to the Github release"
 	@echo "Use make docker-push-all to push the images to a registry"
@@ -164,6 +184,7 @@ docker-push-all:
 	ARCH=arm make docker-push
 	ARCH=arm64 make docker-push
 	ARCH=ppc64le make docker-push
+	ARCH=s390x make docker-push
 
 flannel-git:
 	ARCH=amd64 REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-amd64.docker docker-push
@@ -172,3 +193,4 @@ flannel-git:
 	ARCH=arm REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-arm.docker docker-push
 	ARCH=arm64 REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-arm64.docker docker-push
 	ARCH=ppc64le REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-ppc64le.docker docker-push
+	ARCH=s390x REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-s390x.docker docker-push


### PR DESCRIPTION
THis means we're now using a newer version of go and
arm-linux-gnueabihf-gcc instead of arm-linux-gnueabi-gcc