### PR TITLE
Added compatibility check to compare GBP for VXLAN

### DIFF
--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -291,6 +291,10 @@ func vxlanLinksIncompat(l1, l2 netlink.Link) string {
 		return fmt.Sprintf("port: %v vs %v", v1.Port, v2.Port)
 	}
 
+	if v1.GBP != v2.GBP {
+		return fmt.Sprintf("gbp: %v vs %v", v1.GBP, v2.GBP)
+	}
+
 	return ""
 }
 


### PR DESCRIPTION
## Description
vxlanLinkIncompat function did not check GBP so it was possible that
changes in the config would not be refreshed.

Fixes #562

