### PR TITLE
Fix a bug with the iface-regex that always returned an error

### DIFF
--- a/main.go
+++ b/main.go
@@ -374,7 +374,10 @@ func LookupExtIface(ifname string, ifregex string) (*backend.ExternalInterface, 
 			}
 		}
 
-		return nil, fmt.Errorf("Could not match pattern %s to any of the available network interfaces", ifregex)
+		// Check that nothing was matched
+		if iface == nil {
+			return nil, fmt.Errorf("Could not match pattern %s to any of the available network interfaces", ifregex)
+		}
 	} else {
 		log.Info("Determining IP address of default interface")
 		if iface, err = ip.GetDefaultGatewayIface(); err != nil {


### PR DESCRIPTION
## Description
Fixes a bug that prevented iface-regexes from ever returning a proper interface.  Bug was introduced with https://github.com/coreos/flannel/pull/754

