### PR TITLE
Add new backend vxlan-over-hostgw

### DIFF
--- a/backend/vxlan/hostgw.go
+++ b/backend/vxlan/hostgw.go
@@ -1,0 +1,160 @@
+package vxlan
+
+import (
+	"sync"
+	"time"
+	"strings"
+	"strconv"
+
+	"golang.org/x/net/context"
+	"github.com/coreos/flannel/backend"
+	"github.com/coreos/flannel/backend/hostgw"
+	"github.com/coreos/flannel/subnet"
+	log "github.com/golang/glog"
+	"github.com/vishvananda/netlink"
+	"github.com/coreos/flannel/pkg/ip"
+)
+
+type vxlanGWNetwork struct {
+	network
+	hostGWNetwork* hostgw.HostGWNetwork
+	localNetworkMask uint32
+}
+
+type VXLANGWBackend struct {
+	VXLANBackend
+}
+
+func init() {
+	backend.Register("vxlan-over-hostgw", NewHostGw)
+}
+
+func getLocalNetworkMask(extIface *backend.ExternalInterface) uint32 {
+	var networkLen string = "32"
+	var networkMask uint32 = 0xffffffff
+	if addrs, err := extIface.Iface.Addrs(); err == nil {
+		for _, addr := range addrs {
+			 parts := strings.Split(addr.String(), "/")
+			 if len(parts) == 2 {
+				 if parts[0] != extIface.ExtAddr.String() {
+					 continue
+				 }
+				 networkLen = parts[1]
+				 break
+			 }
+		 }
+	}
+	i, err := strconv.Atoi(networkLen)
+	if err == nil && i <= 32 {
+		networkMask = (networkMask << uint32(32 - i))
+	}
+	return networkMask
+}
+
+func NewHostGw(sm subnet.Manager, extIface *backend.ExternalInterface) (backend.Backend, error) {
+	backend := &VXLANGWBackend{
+		VXLANBackend: VXLANBackend{
+			subnetMgr: sm,
+			extIface:  extIface,
+			backendType: "vxlan-over-hostgw",
+		},
+	}
+	return backend, nil
+}
+
+func (be *VXLANGWBackend) RegisterNetwork(ctx context.Context, config *subnet.Config) (backend.Network, error) {
+	vxlan, err := be.VXLANBackend.RegisterNetwork(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	vxlanNetwork := vxlan.(*network)
+	n := &vxlanGWNetwork {
+		network: *vxlanNetwork,
+		hostGWNetwork: hostgw.NewHostGWNetwork(
+			vxlanNetwork.subnetMgr,
+			vxlanNetwork.ExtIface,
+			vxlanNetwork.SimpleNetwork.SubnetLease,
+		),
+		localNetworkMask: getLocalNetworkMask(vxlanNetwork.ExtIface),
+	}
+	return n, err
+}
+
+func (nw *vxlanGWNetwork) MTU() int {
+	return nw.network.MTU()
+}
+
+func (nw *vxlanGWNetwork) Lease() *subnet.Lease {
+	return nw.network.Lease()
+}
+
+func (nw *vxlanGWNetwork) filterLocalSubnetEvents(batch []subnet.Event) []subnet.Event{
+	local_ip := ip.FromIP(nw.network.ExtIface.ExtAddr)
+	filteredEvent := make([]subnet.Event, 0)
+	for _, event := range batch {
+		if event.Type != subnet.EventAdded && event.Type != subnet.EventRemoved {
+			continue
+		}
+		remote_ip := event.Lease.Attrs.PublicIP
+		if ((uint32)(local_ip ^ remote_ip) & nw.localNetworkMask ) != 0{
+			continue
+		}
+		filteredEvent = append(filteredEvent, event)
+	}
+	return filteredEvent
+
+}
+
+func (nw *vxlanGWNetwork) Run(ctx context.Context) {
+	misses := make(chan *netlink.Neigh, 100)
+	// Unfortunately MonitorMisses does not take a cancel channel
+	// as there's no wait to interrupt netlink socket recv
+	go nw.dev.MonitorMisses(misses)
+
+	wg := sync.WaitGroup{}
+
+	events := make(chan []subnet.Event)
+	wg.Add(1)
+	go func() {
+		subnet.WatchLeases(ctx, nw.subnetMgr, nw.SubnetLease, events)
+		wg.Done()
+	}()
+	// add host gw watches
+	nw.hostGWNetwork.SetupRun(ctx, wg)
+
+	defer wg.Wait()
+
+	select {
+	case initialEventsBatch := <-events:
+		for {
+			err := nw.handleInitialSubnetEvents(initialEventsBatch)
+			if err == nil {
+				// host gw check
+				filtered_events := nw.filterLocalSubnetEvents(initialEventsBatch)
+				nw.hostGWNetwork.HandleSubnetEvents(filtered_events)
+				break
+			}
+			log.Error(err, " About to retry")
+			time.Sleep(time.Second)
+		}
+
+	case <-ctx.Done():
+		return
+	}
+
+	for {
+		select {
+		case miss := <-misses:
+			nw.handleMiss(miss)
+
+		case evtBatch := <-events:
+			nw.handleSubnetEvents(evtBatch)
+			// host gw check
+			filtered_events := nw.filterLocalSubnetEvents(evtBatch)
+			nw.hostGWNetwork.HandleSubnetEvents(filtered_events)
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/backend/vxlan/hostgw.go
+++ b/backend/vxlan/hostgw.go
@@ -1,3 +1,17 @@
+// Copyright 2015 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package vxlan
 
 import (

--- a/backend/vxlan/vxlan_network.go
+++ b/backend/vxlan/vxlan_network.go
@@ -33,7 +33,6 @@ import (
 
 type network struct {
 	backend.SimpleNetwork
-	extIface  *backend.ExternalInterface
 	dev       *vxlanDevice
 	routes    routes
 	subnetMgr subnet.Manager
@@ -115,7 +114,7 @@ func (nw *network) handleSubnetEvents(batch []subnet.Event) {
 		case subnet.EventAdded:
 			log.V(1).Info("Subnet added: ", event.Lease.Subnet)
 
-			if event.Lease.Attrs.BackendType != "vxlan" {
+			if event.Lease.Attrs.BackendType != "vxlan" && event.Lease.Attrs.BackendType != "vxlan-over-hostgw" {
 				log.Warningf("Ignoring non-vxlan subnet: type=%v", event.Lease.Attrs.BackendType)
 				continue
 			}
@@ -131,7 +130,7 @@ func (nw *network) handleSubnetEvents(batch []subnet.Event) {
 		case subnet.EventRemoved:
 			log.V(1).Info("Subnet removed: ", event.Lease.Subnet)
 
-			if event.Lease.Attrs.BackendType != "vxlan" {
+			if event.Lease.Attrs.BackendType != "vxlan"  && event.Lease.Attrs.BackendType != "vxlan-over-hostgw" {
 				log.Warningf("Ignoring non-vxlan subnet: type=%v", event.Lease.Attrs.BackendType)
 				continue
 			}
@@ -172,7 +171,7 @@ func (nw *network) handleInitialSubnetEvents(batch []subnet.Event) error {
 
 	// Run through the events "marking" ones that should be skipped
 	for eventMarkerIndex, evt := range batch {
-		if evt.Lease.Attrs.BackendType != "vxlan" {
+		if evt.Lease.Attrs.BackendType != "vxlan"  && evt.Lease.Attrs.BackendType != "vxlan-over-hostgw" {
 			log.Warningf("Ignoring non-vxlan subnet(%s): type=%v", evt.Lease.Subnet, evt.Lease.Attrs.BackendType)
 			eventMarker[eventMarkerIndex] = true
 			continue


### PR DESCRIPTION
This new backend "is a" vxlan backend, only that it "has a" host-gw
backend.
It works the same as vxlan, with the following extra functionality:
1. the backend would calculate its local network mask on start
2. when receiving network events, it would forward the event to host-gw
backend if the network events belong to local network

## Description
With this backend, the nodes in the same local network would reach each other  via direct route, and the nodes in different local network would reach each other via vxlan.
This setup would help improving network bandwidth usage within local network (comparing to pure vxlan), and still make networking accessible across  networks boundary. 

The relationship between vxlan, host-gw and vxlan-over-hostgw is as following:
1. vxlan  <--> host-gw:   could not reach each other
2. vxlan <--> vxlan-over-hostgw:  the flannel networks connected to each other by vxlan
3. host-gw <--> vxlan-over-hostgw: the flannel networks connected to each other by host-gw if they are in same local network, otherwise they could not reach each other
4. vxlan-over-host <--> vxlan-over-host:  networks connected by host-gw if they are in same local network, otherwise connected by vxlan

##Tests

>#etcdctl  get /coreos.com/network/config
{ "Network": "170.0.0.0/8", "SubnetLen": 20, "Backend": {"Type": "vxlan-over-hostgw"} }

Test Env setup: 
>4 nodes with node1/node2/node3 are in network 10.19.138.0/24, while node4 in network 10.19.140.0/24
After starting flanneld on each nodes, the route table is as following:

>node 1
#ip route
default via 10.19.138.1 dev enp0s3 
10.19.138.0/24 dev enp0s3  proto kernel  scope link  src 10.19.138.179 
170.0.0.0/8 dev flannel.1 
170.1.128.0/20 dev docker0  proto kernel  scope link  src 170.1.128.1 
170.2.16.0/20 via 10.19.138.182 dev enp0s3 
170.4.208.0/20 via 10.19.138.164 dev enp0s3 
192.168.57.0/24 dev enp0s8  proto kernel  scope link  src 192.168.57.7 

>node 2
 #ip route
default via 10.19.138.1 dev enp0s8 
10.19.138.0/24 dev enp0s8  proto kernel  scope link  src 10.19.138.164  
170.0.0.0/8 dev flannel.1 
170.1.128.0/20 via 10.19.138.179 dev enp0s8 
170.2.16.0/20 via 10.19.138.182 dev enp0s8 
170.4.208.0/20 dev docker0  proto kernel  scope link  src 170.4.208.1 
192.168.57.0/24 dev enp0s3  proto kernel  scope link  src 192.168.57.2 


>node 3
#ip route
default via 10.19.138.1 dev enp0s8 
10.19.138.0/24 dev enp0s8  proto kernel  scope link  src 10.19.138.182  
170.0.0.0/8 dev flannel.1 
170.1.128.0/20 via 10.19.138.179 dev enp0s8 
170.2.16.0/20 dev docker0  proto kernel  scope link  src 170.2.16.1 
170.4.208.0/20 via 10.19.138.164 dev enp0s8 
192.168.57.0/24 dev enp0s3  proto kernel  scope link  src 192.168.57.6 


>node 4 
#ip route
default via 10.19.140.1 dev eth0 
10.19.140.0/24 dev eth0  proto kernel  scope link  src 10.19.140.10 
170.0.0.0/8 dev flannel.1 
170.3.176.0/20 dev docker0  proto kernel  scope link  src 170.3.176.1 
192.168.100.0/24 dev eth1  proto kernel  scope link  src 192.168.100.42 

### Test steps:
1. On each nodes, run a simple docker process:
>docker run --rm -it alpine sh

2. On each container, run `ping` to check connectivity between containers across nodes.

### Expect:
>All container could reach each other.

### Result:
>As expected.
## Todos
- [ ] Tests
- [ ] Documentation