### PR TITLE
backend/vxlan: Add support for "direct routing"

### DIFF
--- a/Documentation/backends.md
+++ b/Documentation/backends.md
@@ -22,6 +22,7 @@ Type and options:
 * `VNI` (number): VXLAN Identifier (VNI) to be used. Defaults to 1.
 * `Port` (number): UDP port to use for sending encapsulated packets. Defaults to kernel default, currently 8472.
 * `GBP` (Boolean): Enable [VXLAN Group Based Policy](https://github.com/torvalds/linux/commit/3511494ce2f3d3b77544c79b87511a4ddb61dc89).  Defaults to `false`.
+* `DirectRouting` (Boolean): Enable direct routes (like `host-gw`) when the hosts are on the same subnet. VXLAN will only be used to encapsulate packets to hosts on different subnets. Defaults to `false`.
 
 ### host-gw
 

--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -35,7 +35,8 @@ type vxlanDeviceAttrs struct {
 }
 
 type vxlanDevice struct {
-	link *netlink.Vxlan
+	link          *netlink.Vxlan
+	directRouting bool
 }
 
 func newVXLANDevice(devAttrs *vxlanDeviceAttrs) (*vxlanDevice, error) {

--- a/dist/functional-test.sh
+++ b/dist/functional-test.sh
@@ -143,8 +143,8 @@ multi_test() {
         docker run --name=flannel-host$host -d -it --privileged --entrypoint /bin/sh $flannel_img
 
         # Start two flanneld instances
-        docker exec -d flannel-host$host sh -c "/opt/bin/flanneld -subnet-file /vxlan.env -etcd-prefix=/vxlan/network --etcd-endpoints=$etcd_endpt 2>vxlan.log"
-        docker exec -d flannel-host$host sh -c "/opt/bin/flanneld -subnet-file /hostgw.env -etcd-prefix=/hostgw/network --etcd-endpoints=$etcd_endpt 2>hostgw.log"
+        docker exec -d flannel-host$host sh -c "/opt/bin/flanneld -v 10 -subnet-file /vxlan.env -etcd-prefix=/vxlan/network --etcd-endpoints=$etcd_endpt 2>vxlan.log"
+        docker exec -d flannel-host$host sh -c "/opt/bin/flanneld -v 10 -subnet-file /hostgw.env -etcd-prefix=/hostgw/network --etcd-endpoints=$etcd_endpt 2>hostgw.log"
     done
 
 	echo flannels running


### PR DESCRIPTION
This skips vxlan encapsulation if the hosts are on the same subnet