### PR TITLE
add ca-certificates

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -4,7 +4,7 @@ MAINTAINER Tom Denham <tom@tigera.io>
 
 ENV FLANNEL_ARCH=amd64
 
-RUN apk add --no-cache iproute2 net-tools
+RUN apk add --no-cache iproute2 net-tools ca-certificates && update-ca-certificates
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
 COPY dist/mk-docker-opts.sh /opt/bin/


### PR DESCRIPTION
fix: add ca-certificates

Backend like aws-vpc or ali-vpc call https IaaS API will failed without ca-certificates.