### PR TITLE
Add flag validation for subnet-lease-renew-margin

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func init() {
 	flannelFlags.Var(&opts.ifaceRegex, "iface-regex", "regex expression to match the first interface to use (IP or name) for inter-host communication. Can be specified multiple times to check each regex in order. Returns the first match found. Regexes are checked after specific interfaces specified by the iface option have already been checked.")
 	flannelFlags.StringVar(&opts.subnetFile, "subnet-file", "/run/flannel/subnet.env", "filename where env variables (subnet, MTU, ... ) will be written to")
 	flannelFlags.StringVar(&opts.publicIP, "public-ip", "", "IP accessible by other nodes for inter-host communication")
-	flannelFlags.IntVar(&opts.subnetLeaseRenewMargin, "subnet-lease-renew-margin", 60, "subnet lease renewal margin, in minutes.")
+	flannelFlags.IntVar(&opts.subnetLeaseRenewMargin, "subnet-lease-renew-margin", 60, "subnet lease renewal margin, in minutes, ranging from 1 to 1439")
 	flannelFlags.BoolVar(&opts.ipMasq, "ip-masq", false, "setup IP masquerade rule for traffic destined outside of overlay network")
 	flannelFlags.BoolVar(&opts.kubeSubnetMgr, "kube-subnet-mgr", false, "contact the Kubernetes API for subnet assignment instead of etcd.")
 	flannelFlags.StringVar(&opts.kubeApiUrl, "kube-api-url", "", "Kubernetes API server URL. Does not need to be specified if flannel is running in a pod.")
@@ -175,6 +175,12 @@ func main() {
 	}
 
 	flagutil.SetFlagsFromEnv(flannelFlags, "FLANNELD")
+
+	// Validate flags
+	if opts.subnetLeaseRenewMargin >= 24*60 || opts.subnetLeaseRenewMargin <= 0 {
+		log.Error("Invalid subnet-lease-renew-margin option, out of acceptable range")
+		os.Exit(1)
+	}
 
 	// Work out which interface to use
 	var extIface *backend.ExternalInterface


### PR DESCRIPTION
when the subnet-lease-renew-margin is large than 1440(minutes), etcdv2
subnet manager would keep renew lease, causing high CPU load to flanneld
and etcd.

