### PR TITLE
Fix route deletion when replacing route in hostgw backend

### DIFF
--- a/backend/hostgw/hostgw_network.go
+++ b/backend/hostgw/hostgw_network.go
@@ -29,12 +29,11 @@ import (
 )
 
 type network struct {
-	name      string
-	extIface  *backend.ExternalInterface
-	linkIndex int
-	rl        []netlink.Route
-	lease     *subnet.Lease
-	sm        subnet.Manager
+	name     string
+	extIface *backend.ExternalInterface
+	rl       []netlink.Route
+	lease    *subnet.Lease
+	sm       subnet.Manager
 }
 
 func (n *network) Lease() *subnet.Lease {
@@ -43,6 +42,10 @@ func (n *network) Lease() *subnet.Lease {
 
 func (n *network) MTU() int {
 	return n.extIface.Iface.MTU
+}
+
+func (n *network) LinkIndex() int {
+	return n.extIface.Iface.Index
 }
 
 func (n *network) Run(ctx context.Context) {
@@ -90,7 +93,7 @@ func (n *network) handleSubnetEvents(batch []subnet.Event) {
 			route := netlink.Route{
 				Dst:       evt.Lease.Subnet.ToIPNet(),
 				Gw:        evt.Lease.Attrs.PublicIP.ToIP(),
-				LinkIndex: n.linkIndex,
+				LinkIndex: n.LinkIndex(),
 			}
 
 			// Check if route exists before attempting to add it
@@ -129,7 +132,7 @@ func (n *network) handleSubnetEvents(batch []subnet.Event) {
 			route := netlink.Route{
 				Dst:       evt.Lease.Subnet.ToIPNet(),
 				Gw:        evt.Lease.Attrs.PublicIP.ToIP(),
-				LinkIndex: n.linkIndex,
+				LinkIndex: n.LinkIndex(),
 			}
 			if err := netlink.RouteDel(&route); err != nil {
 				log.Errorf("Error deleting route to %v: %v", evt.Lease.Subnet, err)

--- a/backend/hostgw/hostgw_network.go
+++ b/backend/hostgw/hostgw_network.go
@@ -107,7 +107,7 @@ func (n *network) handleSubnetEvents(batch []subnet.Event) {
 			if len(routeList) > 0 && !routeList[0].Gw.Equal(route.Gw) {
 				// Same Dst different Gw. Remove it, correct route will be added below.
 				log.Warningf("Replacing existing route to %v via %v with %v via %v.", evt.Lease.Subnet, routeList[0].Gw, evt.Lease.Subnet, evt.Lease.Attrs.PublicIP)
-				if err := netlink.RouteDel(&route); err != nil {
+				if err := netlink.RouteDel(&routeList[0]); err != nil {
 					log.Errorf("Error deleting route to %v: %v", evt.Lease.Subnet, err)
 					continue
 				}


### PR DESCRIPTION
## Description

Bug fix for the hostgw backend.

We noticed (#801) that the Flannel was not replacing routes when new nodes were added to the cluster: we saw these error messages in our production cluster

```
[network.go:83] Subnet added: 10.32.10.0/24 via 10.68.29.72\n","stream":"stderr","time":"2017-08-29T17:00:21.968055987Z"}
[network.go:106] Replacing existing route to 10.32.10.0/24 via 10.68.26.131 with 10.32.10.0/24 via 10.68.29.72.\n","stream":"stderr","time":"2017-08-29T17:00:21.968211104Z"}
[network.go:108] Error deleting route to 10.32.10.0/24: no such process\n","stream":"stderr","time":"2017-08-29T17:00:21.96826321Z"}
```

This was happening when an existing route was being replaced with a new route.

This turns out to be for 2 reasons:

1. The wrong LinkIndex was being set on the netlink messages: the LinkIndex was always set to 0, when it should be set to the index of the external network interface. (`extIface.Iface.Index`)
2. Instead of deleting the **old** route, this code path was trying to delete the **new** route. Since the new route doesn't exist, the deletion fails. 

I tested Flannel with this patch in our cluster and now replacing routes works correctly.


Fixes #801.