### PR TITLE
Remove Library copy commands from dockefiles

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM armel/busybox:glibc
+FROM arm32v7/busybox:glibc
 
 MAINTAINER Tom Denham <tom@tigera.io>
 
@@ -7,9 +7,5 @@ ENV FLANNEL_ARCH=arm
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
 COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-$FLANNEL_ARCH /lib/libpthread.so.0
-COPY dist/ld64.so.1-$FLANNEL_ARCH /lib/ld64.so.1
-COPY dist/libc.so.6-$FLANNEL_ARCH /lib/libc.so.6
-
 
 ENTRYPOINT ["/opt/bin/flanneld"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM aarch64/busybox:glibc
+FROM arm64v8/busybox:glibc
 
 MAINTAINER Tom Denham <tom@tigera.io>
 
@@ -7,8 +7,5 @@ ENV FLANNEL_ARCH=arm64
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
 COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-$FLANNEL_ARCH /lib/libpthread.so.0
-COPY dist/ld64.so.1-$FLANNEL_ARCH /lib/ld64.so.1
-COPY dist/libc.so.6-$FLANNEL_ARCH /lib/libc.so.6
 
 ENTRYPOINT ["/opt/bin/flanneld"]

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -7,8 +7,5 @@ ENV FLANNEL_ARCH=ppc64le
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
 COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-$FLANNEL_ARCH /lib/libpthread.so.0
-COPY dist/ld64.so.1-$FLANNEL_ARCH /lib/ld64.so.1
-COPY dist/libc.so.6-$FLANNEL_ARCH /lib/libc.so.6
 
 ENTRYPOINT ["/opt/bin/flanneld"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -7,8 +7,5 @@ ENV FLANNEL_ARCH=s390x
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/iptables-$FLANNEL_ARCH /usr/local/bin/iptables
 COPY dist/mk-docker-opts.sh /opt/bin/
-COPY dist/libpthread.so.0-$FLANNEL_ARCH /lib/libpthread.so.0
-COPY dist/ld64.so.1-$FLANNEL_ARCH /lib/ld64.so.1
-COPY dist/libc.so.6-$FLANNEL_ARCH /lib/libc.so.6
 
 ENTRYPOINT ["/opt/bin/flanneld"]


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - Fixes #812

This contains following modifications
1. Use supported arm images as baseimage in the dockefiles
2. Remove copying of libraries which is not necessary now, because latest busybox contains all the dependent libs.

## Todos
- [x] Tests - generated all the images and ran ppc64le image
- [x] Documentation - `N/A`

