### PR TITLE
Makefile: Stop pulling the unused lib from kube-cross

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 dist/*.tar.gz
 dist/flanneld*
-dist/libpthread*
-dist/ld64*
-dist/libc*
 dist/*.aci
 dist/*.docker
 cover.out


### PR DESCRIPTION
The Dockerfiles used to need some custom libs. They don't anymore