### PR TITLE
Fix printf verb %s of wrong type

### DIFF
--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -114,7 +114,7 @@ func (dev *vxlanDevice) Configure(ipn ip.IP4Net) error {
 
 	// flannel will never make this happen. This situation can only be caused by a user, so get them to sort it out.
 	if len(existingAddrs) > 1 {
-		return fmt.Errorf("link has incompatible addresses. Remove additional addresses and try again. %s", dev.link)
+		return fmt.Errorf("link has incompatible addresses. Remove additional addresses and try again. %#v", dev.link)
 	}
 
 	// If the device has an incompatible address then delete it. This can happen if the lease changes for example.


### PR DESCRIPTION
## Description
 
`%#v` is more readable than `%s`.

%s generate error like:
```
&{{%!s(int=0) %!s(int=0) %!s(int=0)   0 %!s(uint32=0) %!s(int=0) %!s(int=0) <nil>  %!s(*netlink.LinkStatistics=<nil>) %!s(int=0) %!s(*netlink.LinkXdp=<nil>)  <nil> unknown} %!s(int=0) %!s(int=0) <nil> <nil> %!s(int=0) %!s(int=0) %!s(bool=false) %!s(bool=false) %!s(bool=false) %!s(bool=false) %!s(bool=false) %!s(bool=false) %!s(bool=false) %!s(bool=false) %!s(int=0) %!s(int=0) %!s(int=0) %!s(int=0) %!s(int=0)}
```

while %#v:
```
&netlink.Vxlan{LinkAttrs:netlink.LinkAttrs{Index:0, MTU:0, TxQLen:0, Name:"", HardwareAddr:net.HardwareAddr(nil), Flags:0x0, RawFlags:0x0, ParentIndex:0, MasterIndex:0, Namespace:interface {}(nil), Alias:"", Statistics:(*netlink.LinkStatistics)(nil), Promisc:0, Xdp:(*netlink.LinkXdp)(nil), EncapType:"", Protinfo:(*netlink.Protinfo)(nil), OperState:0x0}, VxlanId:0, VtepDevIndex:0, SrcAddr:net.IP(nil), Group:net.IP(nil), TTL:0, TOS:0, Learning:false, Proxy:false, RSC:false, L2miss:false, L3miss:false, UDPCSum:false, NoAge:false, GBP:false, Age:0, Limit:0, Port:0, PortLow:0, PortHigh:0}
``` 
