### PR TITLE
Fix error message in ipmasq

### DIFF
--- a/network/ipmasq.go
+++ b/network/ipmasq.go
@@ -51,7 +51,7 @@ func ipMasqRulesExist(ipt IPTablesRules, ipn ip.IP4Net, lease *subnet.Lease) (bo
 		exists, err := ipt.Exists("nat", "POSTROUTING", rule...)
 		if err != nil {
 			// this shouldn't ever happen
-			return false, fmt.Errorf("failed to check rule existence", err)
+			return false, fmt.Errorf("failed to check rule existence: %v", err)
 		}
 		if !exists {
 			return false, nil


### PR DESCRIPTION
Signed-off-by: sakeven <jc5930@sina.cn>

## Description

bug fix.
`fmt.Errorf("failed to check rule existence", err)` missed ": %v"。
No formatting directive in Errorf call.

