### PR TITLE
kube-flannel-cfg: enable hairpin mode

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -57,6 +57,7 @@ data:
       "name": "cbr0",
       "type": "flannel",
       "delegate": {
+        "hairpinMode": true,
         "isDefaultGateway": true
       }
     }


### PR DESCRIPTION
Hairpin mode is needed to allow pods to communicate with themselves via
Service IP. This change is required as the kubelet --hairpin-mode flag
is not supported when CNI is being used.

This patch is picked from https://github.com/coreos/tectonic-installer/pull/1640

I verified it on K8S 1.7.5 + Flannel vxlan backend, it works as expected.