### PR TITLE
network: move ipmasq management into platform-specific files

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/coreos/pkg/flagutil"
 	log "github.com/golang/glog"
 	"golang.org/x/net/context"
@@ -285,7 +284,7 @@ func main() {
 
 	// Set up ipMasq if needed
 	if opts.ipMasq {
-		go setupIPMasq(config, bn)
+		go network.SetupAndEnsureIPMasq(config.Network, bn.Lease())
 	}
 
 	if err := WriteSubnetFile(opts.subnetFile, config.Network, opts.ipMasq, bn); err != nil {
@@ -551,26 +550,6 @@ func mustRunHealthz() {
 		log.Errorf("Start healthz server error. %v", err)
 		panic(err)
 	}
-}
-
-func setupIPMasq(config *subnet.Config, bn backend.Network) {
-	ipt, err := iptables.New()
-	if err != nil {
-		// if we can't find iptables, give up and return
-		log.Errorf("Failed to set up IP Masquerade. iptables was not found: %v", err)
-		return
-	}
-	defer func() {
-		network.TeardownIPMasq(ipt, config.Network, bn.Lease())
-	}()
-	for {
-		// Ensure that all the rules exist every 5 seconds
-		if err := network.EnsureIPMasq(ipt, config.Network, bn.Lease()); err != nil {
-			log.Errorf("Failed to ensure IP Masquerade: %v", err)
-		}
-		time.Sleep(5 * time.Second)
-	}
-
 }
 
 func ReadSubnetFromSubnetFile(path string) ip.IP4Net {

--- a/network/ipmasq_test.go
+++ b/network/ipmasq_test.go
@@ -74,11 +74,11 @@ func (mock *MockIPTables) AppendUnique(table string, chain string, rulespec ...s
 
 func TestDeleteRules(t *testing.T) {
 	ipt := &MockIPTables{}
-	SetupIPMasq(ipt, ip.IP4Net{}, lease())
+	setupIPMasq(ipt, ip.IP4Net{}, lease())
 	if len(ipt.rules) != 4 {
 		t.Errorf("Should be 4 rules, there are actually %d: %#v", len(ipt.rules), ipt.rules)
 	}
-	TeardownIPMasq(ipt, ip.IP4Net{}, lease())
+	teardownIPMasq(ipt, ip.IP4Net{}, lease())
 	if len(ipt.rules) != 0 {
 		t.Errorf("Should be 0 rules, there are actually %d: %#v", len(ipt.rules), ipt.rules)
 	}
@@ -87,13 +87,13 @@ func TestDeleteRules(t *testing.T) {
 func TestEnsureRules(t *testing.T) {
 	// If any rules are missing, they should be all deleted and recreated in the correct order
 	ipt_correct := &MockIPTables{}
-	SetupIPMasq(ipt_correct, ip.IP4Net{}, lease())
-	// setup a mock instance where we delete some rules and run `EnsureIPMasq`
+	setupIPMasq(ipt_correct, ip.IP4Net{}, lease())
+	// setup a mock instance where we delete some rules and run `ensureIPMasq`
 	ipt_recreate := &MockIPTables{}
-	SetupIPMasq(ipt_recreate, ip.IP4Net{}, lease())
+	setupIPMasq(ipt_recreate, ip.IP4Net{}, lease())
 	ipt_recreate.rules = ipt_recreate.rules[0:2]
-	EnsureIPMasq(ipt_recreate, ip.IP4Net{}, lease())
+	ensureIPMasq(ipt_recreate, ip.IP4Net{}, lease())
 	if !reflect.DeepEqual(ipt_recreate.rules, ipt_correct.rules) {
-		t.Errorf("iptables rules after EnsureIPMasq are incorrected. Expected: %#v, Actual: %#v", ipt_recreate.rules, ipt_correct.rules)
+		t.Errorf("iptables rules after ensureIPMasq are incorrected. Expected: %#v, Actual: %#v", ipt_recreate.rules, ipt_correct.rules)
 	}
 }


### PR DESCRIPTION
## Description
As requested in #832 , we're breaking up the changes into smaller commits.  This PR moves the Setup, monitoring, and teardown of IPMasq settings into platform-specific files.  This is one of the requirements to get Flannel to build on Windows.

From the original PR (#832):

> The goal is to enable users to provision a Kubernetes cluster with windows nodes in VXLAN mode or mixed windows and Linux nodes in host-gw mode.