### PR TITLE
make sure flanneld got QoS class "Guaranteed" to have lower oom_score_adj

### DIFF
--- a/Documentation/k8s-manifests/kube-flannel-legacy.yml
+++ b/Documentation/k8s-manifests/kube-flannel-legacy.yml
@@ -58,6 +58,13 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
         securityContext:
           privileged: true
         env:

--- a/Documentation/kube-flannel-aliyun.yml
+++ b/Documentation/kube-flannel-aliyun.yml
@@ -114,6 +114,13 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
         securityContext:
           privileged: true
         env:

--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -124,6 +124,13 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
         securityContext:
           privileged: true
         env:

--- a/Documentation/minikube.yml
+++ b/Documentation/minikube.yml
@@ -59,6 +59,13 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
Usually flanneld consumes 5m CPU and 15Mi memory according to "kubectl top".

## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

Flannel pod gets default QoS class "BestEffort" when it doesn't specify cpu and memory resources,
this makes its oom_score_adj to be 1000 and thus is more likely killed first when free memory isn't enough.

This patch assigns same amount of  cpu/mem request and amount, makes Flanneld pod gets QoS class "Guaranteed" and oom_score_adj -998 as described at https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/#node-oom-behavior.