### PR TITLE
README.md: fix link to kubernetes documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Flannel can be added to any existing Kubernetes cluster though it's simplest to 
 For Kubernetes v1.6+
 `kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml`
 
-See [Kubernetes](Documentation/Kubernetes.md) for more details.
+See [Kubernetes](Documentation/kubernetes.md) for more details.
 
 ## Getting started on Docker
 


### PR DESCRIPTION
Link to kubernetes documentation was broken (wrong capitalization).

## Description
Type of fix: documentation. Just a simple typo fix in the README in the git root to fix the link to the kubernetes docs.