### PR TITLE
MAINTAINER is deprecated, using LABEL now

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc
 
-MAINTAINER Tom Denham <tom@tigera.io>
+LABEL maintainer="Tom Denham <tom@tigera.io>"
 
 ENV FLANNEL_ARCH=amd64
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,6 +1,6 @@
 FROM arm32v7/busybox:glibc
 
-MAINTAINER Tom Denham <tom@tigera.io>
+LABEL maintainer="Tom Denham <tom@tigera.io>"
 
 ENV FLANNEL_ARCH=arm
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,6 +1,6 @@
 FROM arm64v8/busybox:glibc
 
-MAINTAINER Tom Denham <tom@tigera.io>
+LABEL maintainer="Tom Denham <tom@tigera.io>"
 
 ENV FLANNEL_ARCH=arm64
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,6 +1,6 @@
 FROM ppc64le/busybox:glibc
 
-MAINTAINER Tom Denham <tom@tigera.io>
+LABEL maintainer="Tom Denham <tom@tigera.io>"
 
 ENV FLANNEL_ARCH=ppc64le
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,6 +1,6 @@
 FROM s390x/busybox:glibc
 
-MAINTAINER Tom Denham <tom@tigera.io>
+LABEL maintainer="Tom Denham <tom@tigera.io>"
 
 ENV FLANNEL_ARCH=s390x
 


### PR DESCRIPTION
`MAINTAINER` command has been deprecated (https://docs.docker.com/engine/reference/builder/#maintainer-deprecated), recommended resolution is using `LABEL`