### PR TITLE
Log kubernetes public ip override

### DIFF
--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -241,7 +241,12 @@ func (ksm *kubeSubnetManager) AcquireLease(ctx context.Context, attrs *subnet.Le
 		n.Annotations[backendTypeAnnotation] = attrs.BackendType
 		n.Annotations[backendDataAnnotation] = string(bd)
 		if n.Annotations[backendPublicIPOverwriteAnnotation] != "" {
-			n.Annotations[backendPublicIPAnnotation] = n.Annotations[backendPublicIPOverwriteAnnotation]
+			if n.Annotations[backendPublicIPAnnotation] != n.Annotations[backendPublicIPOverwriteAnnotation] {
+				glog.Infof("Overriding public ip with '%s' from node annotation '%s'",
+					n.Annotations[backendPublicIPOverwriteAnnotation],
+					backendPublicIPOverwriteAnnotation)
+				n.Annotations[backendPublicIPAnnotation] = n.Annotations[backendPublicIPOverwriteAnnotation]
+			}
 		} else {
 			n.Annotations[backendPublicIPAnnotation] = attrs.PublicIP.String()
 		}


### PR DESCRIPTION
Fixes missing logging mentioned in #712 