### PR TITLE
Fix e2e tests for non-amd64 archs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/*.tar.gz
 dist/flanneld*
 dist/*.docker
+dist/here.txt
 cover.out
 .editorconfig
 .idea/

--- a/dist/functional-test-k8s.sh
+++ b/dist/functional-test-k8s.sh
@@ -107,11 +107,13 @@ test_vxlan() {
     pings
 }
 
+if [[ ${ARCH} == "amd64" ]]; then
 test_udp() {
     start_flannel udp
     create_ping_dest # creates ping_dest1 and ping_dest2 variables
     pings
 }
+fi
 
 test_host-gw() {
     start_flannel host-gw

--- a/dist/functional-test.sh
+++ b/dist/functional-test.sh
@@ -84,11 +84,13 @@ test_vxlan_ping() {
     pings
 }
 
+if [[ ${ARCH} == "amd64" ]]; then
 test_udp_ping() {
     write_config_etcd udp
     create_ping_dest # creates ping_dest1 and ping_dest2 variables
     pings
 }
+fi
 
 test_host-gw_ping() {
     write_config_etcd host-gw
@@ -115,11 +117,13 @@ test_vxlan_perf() {
     perf
 }
 
+if [[ ${ARCH} == "amd64" ]]; then
 test_udp_perf() {
     write_config_etcd udp
 	create_ping_dest
     perf
 }
+fi
 
 perf() {
     # Perf test - run iperf server on flannel1 and client on flannel2


### PR DESCRIPTION
This PR will fix following things:

- Copy the qemu binaries for e2e-test target
- Remove redundant make targets
- Disable the udp tests for non-amd64 architectures
- Gitignore `dist/here.txt` file