### PR TITLE
Add portmap plugin to CNI conf

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -55,11 +55,21 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
-      "type": "flannel",
-      "delegate": {
-        "hairpinMode": true,
-        "isDefaultGateway": true
-      }
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
     }
   net-conf.json: |
     {
@@ -100,7 +110,7 @@ spec:
         args:
         - -f
         - /etc/kube-flannel/cni-conf.json
-        - /etc/cni/net.d/10-flannel.conf
+        - /etc/cni/net.d/10-flannel.conflist
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Though not required, it's recommended that flannel uses the Kubernetes API as it
 
 Flannel can be added to any existing Kubernetes cluster though it's simplest to add `flannel` before any pods using the pod network have been started.
 
-For Kubernetes v1.6+
+For Kubernetes v1.7+
 `kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml`
 
 See [Kubernetes](Documentation/kubernetes.md) for more details.


### PR DESCRIPTION
## Description
The portmap plugin is needed for hostPorts to work

The CNI [portmap capability was added in k8s 1.7](https://github.com/kubernetes/kubernetes/issues/23920#issuecomment-306543120). I was able to get past the issue by using the updated kube-flannel.yml on a 1.8.3 cluster.

Closes: https://github.com/coreos/flannel/issues/887


## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
