### PR TITLE
subnet/etcdv2/local_manager.go: Fix startup log

### DIFF
--- a/subnet/etcdv2/local_manager.go
+++ b/subnet/etcdv2/local_manager.go
@@ -378,5 +378,9 @@ func isSubnetConfigCompat(config *Config, sn ip.IP4Net) bool {
 }
 
 func (m *LocalManager) Name() string {
-	return fmt.Sprintf("Etcd Local Manager with Previous Subnet: %s", m.previousSubnet.String())
+	previousSubnet := m.previousSubnet.String()
+	if m.previousSubnet.Empty() {
+		previousSubnet = "None"
+	}
+	return fmt.Sprintf("Etcd Local Manager with Previous Subnet: %s", previousSubnet)
 }


### PR DESCRIPTION
Print "None" instead of 0.0.0.0/0 if there's no previous subnet to use

Fixes #767