### PR TITLE
backend/vxlan: Return correct MTU value

### DIFF
--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -144,10 +144,6 @@ func (dev *vxlanDevice) MACAddr() net.HardwareAddr {
 	return dev.link.HardwareAddr
 }
 
-func (dev *vxlanDevice) MTU() int {
-	return dev.link.MTU
-}
-
 type neighbor struct {
 	MAC net.HardwareAddr
 	IP  ip.IP4

--- a/backend/vxlan/vxlan_network.go
+++ b/backend/vxlan/vxlan_network.go
@@ -33,10 +33,13 @@ import (
 
 type network struct {
 	backend.SimpleNetwork
-	extIface  *backend.ExternalInterface
 	dev       *vxlanDevice
 	subnetMgr subnet.Manager
 }
+
+const (
+	encapOverhead = 50
+)
 
 func newNetwork(subnetMgr subnet.Manager, extIface *backend.ExternalInterface, dev *vxlanDevice, _ ip.IP4Net, lease *subnet.Lease) (*network, error) {
 	nw := &network{
@@ -77,7 +80,7 @@ func (nw *network) Run(ctx context.Context) {
 }
 
 func (nw *network) MTU() int {
-	return nw.dev.MTU()
+	return nw.ExtIface.Iface.MTU - encapOverhead
 }
 
 type vxlanLeaseAttrs struct {


### PR DESCRIPTION
Ensure that the correct MTU is being used for vxlan

Fixes #841 