### PR TITLE
backend/extension: Add Wireguard configuration

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -5,6 +5,7 @@ LABEL maintainer="Tom Denham <tom@tigera.io>"
 ENV FLANNEL_ARCH=amd64
 
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables && update-ca-certificates
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -6,6 +6,7 @@ ENV FLANNEL_ARCH=arm
 
 ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables && update-ca-certificates
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -6,6 +6,7 @@ ENV FLANNEL_ARCH=arm64
 
 ADD dist/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables && update-ca-certificates
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -6,6 +6,7 @@ ENV FLANNEL_ARCH=ppc64le
 
 ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables && update-ca-certificates
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -6,6 +6,7 @@ ENV FLANNEL_ARCH=s390x
 
 ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables && update-ca-certificates
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/backend/extension/extension.go
+++ b/backend/extension/extension.go
@@ -115,6 +115,7 @@ func (be *ExtensionBackend) RegisterNetwork(ctx context.Context, config *subnet.
 
 	if len(n.postStartupCommand) > 0 {
 		cmd_output, err := runCmd([]string{
+			fmt.Sprintf("NETWORK=%s", config.Network),
 			fmt.Sprintf("SUBNET=%s", lease.Subnet),
 			fmt.Sprintf("PUBLIC_IP=%s", attrs.PublicIP)},
 			"", "sh", "-c", n.postStartupCommand)

--- a/dist/extension-wireguard
+++ b/dist/extension-wireguard
@@ -1,0 +1,11 @@
+{
+  "Network": "10.50.0.0/16",
+  "Backend": {
+    "Type": "extension",
+    "PreStartupCommand": "wg genkey | tee privatekey | wg pubkey",
+    "PostStartupCommand": "export SUBNET_IP=`echo $SUBNET | cut -d'/' -f 1`; ip link del flannel-wg 2>/dev/null; ip link add flannel-wg type wireguard && wg set flannel-wg listen-port 51820 private-key privatekey && ip addr add $SUBNET_IP/32 dev flannel-wg && ip link set flannel-wg up && ip route add $NETWORK dev flannel-wg",
+    "ShutdownCommand": "ip link del flannel-wg",
+    "SubnetAddCommand": "read PUBLICKEY; wg set flannel-wg peer $PUBLICKEY endpoint $PUBLIC_IP:51820 allowed-ips $SUBNET",
+    "SubnetRemoveCommand": "read PUBLICKEY; wg set flannel-wg peer $PUBLICKEY remove"
+  }
+}

--- a/dist/functional-test.sh
+++ b/dist/functional-test.sh
@@ -34,17 +34,17 @@ teardown_suite() {
 }
 
 setup() {
-	# rm any old flannel container that maybe running, ignore error as it might not exist
-	docker rm -f flannel-e2e-test-flannel1 >/dev/null 2>/dev/null
-	assert "docker run --name=flannel-e2e-test-flannel1 -d --privileged $FLANNEL_DOCKER_IMAGE --etcd-endpoints=$etcd_endpt -v 10 >/dev/null"
+    # rm any old flannel container that maybe running, ignore error as it might not exist
+    docker rm -f flannel-e2e-test-flannel1 >/dev/null 2>/dev/null
+    assert "docker run --name=flannel-e2e-test-flannel1 -d --privileged $FLANNEL_DOCKER_IMAGE --etcd-endpoints=$etcd_endpt -v 10 >/dev/null"
 
-	# rm any old flannel container that maybe running, ignore error as it might not exist
-	docker rm -f flannel-e2e-test-flannel2 >/dev/null 2>/dev/null
-	assert "docker run --name=flannel-e2e-test-flannel2 -d --privileged $FLANNEL_DOCKER_IMAGE --etcd-endpoints=$etcd_endpt -v 10 >/dev/null"
+    # rm any old flannel container that maybe running, ignore error as it might not exist
+    docker rm -f flannel-e2e-test-flannel2 >/dev/null 2>/dev/null
+    assert "docker run --name=flannel-e2e-test-flannel2 -d --privileged $FLANNEL_DOCKER_IMAGE --etcd-endpoints=$etcd_endpt -v 10 >/dev/null"
 }
 
 teardown() {
-	docker rm -f flannel-e2e-test-flannel1 flannel-e2e-test-flannel2 flannel-e2e-test-flannel1-iperf flannel-host1 flannel-host2 > /dev/null 2>&1
+    docker rm -f flannel-e2e-test-flannel1 flannel-e2e-test-flannel2 flannel-e2e-test-flannel1-iperf flannel-host1 flannel-host2 > /dev/null 2>&1
 }
 
 write_config_etcd() {
@@ -53,13 +53,13 @@ write_config_etcd() {
         echo "Reading custom conf from $backend"
         flannel_conf=`cat "$backend"`
     else
-	    flannel_conf="{ \"Network\": \"$FLANNEL_NET\", \"Backend\": { \"Type\": \"${backend}\" } }"
+        flannel_conf="{ \"Network\": \"$FLANNEL_NET\", \"Backend\": { \"Type\": \"${backend}\" } }"
     fi
 
-	while ! docker run --rm $ETCDCTL_IMG etcdctl --endpoints=$etcd_endpt set /coreos.com/network/config "$flannel_conf" >/dev/null
-	do
-		sleep 0.1
-	done
+    while ! docker run --rm $ETCDCTL_IMG etcdctl --endpoints=$etcd_endpt set /coreos.com/network/config "$flannel_conf" >/dev/null
+    do
+        sleep 0.1
+    done
 }
 
 create_ping_dest() {
@@ -71,12 +71,18 @@ create_ping_dest() {
 
        # Use declare to allow the host_num variable to be part of the ping_dest variable name. -g is needed to make it global
        declare -g ping_dest$host_num=$(docker "exec" --privileged flannel-e2e-test-flannel$host_num /bin/sh -c '\
-		source /run/flannel/subnet.env && \
-		ip link add name dummy0 type dummy && \
-		ip addr add $FLANNEL_SUBNET dev dummy0 && ip link set dummy0 up && \
-		echo $FLANNEL_SUBNET | cut -f 1 -d "/" ')
+        source /run/flannel/subnet.env && \
+        ip link add name dummy0 type dummy && \
+        ip addr add $FLANNEL_SUBNET dev dummy0 && ip link set dummy0 up && \
+        echo $FLANNEL_SUBNET | cut -f 1 -d "/" ')
     done
 }
+
+#test_wireguard_ping() {
+#    write_config_etcd extension-wireguard
+#    create_ping_dest # creates ping_dest1 and ping_dest2 variables
+#    pings
+#}
 
 test_vxlan_ping() {
     write_config_etcd vxlan
@@ -106,27 +112,27 @@ test_ipip_ping() {
 
 pings() {
     # ping in both directions
-	assert "docker exec --privileged flannel-e2e-test-flannel1 /bin/ping -c 3 $ping_dest2" "Host 1 cannot ping host 2"
-	assert "docker exec --privileged flannel-e2e-test-flannel2 /bin/ping -c 3 $ping_dest1" "Host 2 cannot ping host 1"
+    assert "docker exec --privileged flannel-e2e-test-flannel1 /bin/ping -c 3 $ping_dest2" "Host 1 cannot ping host 2"
+    assert "docker exec --privileged flannel-e2e-test-flannel2 /bin/ping -c 3 $ping_dest1" "Host 2 cannot ping host 1"
 }
 
 # These perf tests don't actually assert on anything
 test_host-gw-perf() {
     write_config_etcd host-gw
-	create_ping_dest
-	perf
+    create_ping_dest
+    perf
 }
 
 test_vxlan_perf() {
     write_config_etcd vxlan
-	create_ping_dest
+    create_ping_dest
     perf
 }
 
 if [[ ${ARCH} == "amd64" ]]; then
 test_udp_perf() {
     write_config_etcd udp
-	create_ping_dest
+    create_ping_dest
     perf
 }
 fi
@@ -137,6 +143,12 @@ test_ipip_perf() {
     perf
 }
 
+#test_wireguard_perf() {
+#    write_config_etcd extension-wireguard
+#    create_ping_dest
+#    perf
+#}
+
 perf() {
     # Perf test - run iperf server on flannel1 and client on flannel2
     docker rm -f flannel-e2e-test-flannel1-iperf 2>/dev/null
@@ -145,20 +157,20 @@ perf() {
 }
 
 test_multi() {
-	flannel_conf_vxlan='{"Network": "10.11.0.0/16", "Backend": {"Type": "vxlan"}}'
-	flannel_conf_host_gw='{"Network": "10.12.0.0/16", "Backend": {"Type": "host-gw"}}'
+    flannel_conf_vxlan='{"Network": "10.11.0.0/16", "Backend": {"Type": "vxlan"}}'
+    flannel_conf_host_gw='{"Network": "10.12.0.0/16", "Backend": {"Type": "host-gw"}}'
 
-	while ! docker run --rm $ETCD_IMG etcdctl --endpoints=$etcd_endpt set /vxlan/network/config "$flannel_conf_vxlan" >/dev/null
-	do
-		sleep 0.1
-	done
+    while ! docker run --rm $ETCD_IMG etcdctl --endpoints=$etcd_endpt set /vxlan/network/config "$flannel_conf_vxlan" >/dev/null
+    do
+        sleep 0.1
+    done
 
-	while ! docker run --rm $ETCD_IMG etcdctl --endpoints=$etcd_endpt set /hostgw/network/config "$flannel_conf_host_gw" >/dev/null
-	do
-		sleep 0.1
-	done
+    while ! docker run --rm $ETCD_IMG etcdctl --endpoints=$etcd_endpt set /hostgw/network/config "$flannel_conf_host_gw" >/dev/null
+    do
+        sleep 0.1
+    done
 
-	for host in 1 2; do
+    for host in 1 2; do
         # rm any old flannel container, ignore error as it might not exist
         docker rm -f flannel-host$host 2>/dev/null >/dev/null
 
@@ -178,25 +190,25 @@ test_multi() {
         done
     done
 
-	# add dummy interface on host1 only so we have a known working IP to ping then ping it from host2
-	vxlan_ping_dest=$(docker exec flannel-host1 /bin/sh -c '\
-		source /vxlan.env &&
-		ip link add name dummy_vxlan type dummy && \
-		ip addr add $FLANNEL_SUBNET dev dummy_vxlan && \
-	       	ip link set dummy_vxlan up && \
-		echo $FLANNEL_SUBNET | cut -f 1 -d "/" ')
+    # add dummy interface on host1 only so we have a known working IP to ping then ping it from host2
+    vxlan_ping_dest=$(docker exec flannel-host1 /bin/sh -c '\
+        source /vxlan.env &&
+        ip link add name dummy_vxlan type dummy && \
+        ip addr add $FLANNEL_SUBNET dev dummy_vxlan && \
+               ip link set dummy_vxlan up && \
+        echo $FLANNEL_SUBNET | cut -f 1 -d "/" ')
 
     hostgw_ping_dest=$(docker exec flannel-host1 /bin/sh -c '\
-		source /hostgw.env &&
-		ip link add name dummy_hostgw type dummy && \
-		ip addr add $FLANNEL_SUBNET dev dummy_hostgw && \
-	       	ip link set dummy_hostgw up && \
-		echo $FLANNEL_SUBNET | cut -f 1 -d "/" ')
+        source /hostgw.env &&
+        ip link add name dummy_hostgw type dummy && \
+        ip addr add $FLANNEL_SUBNET dev dummy_hostgw && \
+               ip link set dummy_hostgw up && \
+        echo $FLANNEL_SUBNET | cut -f 1 -d "/" ')
 
     # Send some pings from host2. Make sure we can send traffic over vxlan or directly.
     # If a particular (wrong) interface is forced then pings should fail
-	assert "docker exec flannel-host2 ping -c 3 $hostgw_ping_dest"
-	assert "docker exec flannel-host2 ping -c 3 $vxlan_ping_dest"
-	assert_fails "docker exec flannel-host2 ping -W 1 -c 1 -I flannel.1 $hostgw_ping_dest"
-	assert_fails "docker exec flannel-host2 ping -W 1 -c 1 -I eth0 $vxlan_ping_dest"
+    assert "docker exec flannel-host2 ping -c 3 $hostgw_ping_dest"
+    assert "docker exec flannel-host2 ping -c 3 $vxlan_ping_dest"
+    assert_fails "docker exec flannel-host2 ping -W 1 -c 1 -I flannel.1 $hostgw_ping_dest"
+    assert_fails "docker exec flannel-host2 ping -W 1 -c 1 -I eth0 $vxlan_ping_dest"
 }


### PR DESCRIPTION
This PR adds
- the wireguard tools to the flannel container images (~0.1MB
size increase)
- an example extensions config
- a one-line change to extension.go to pass in the flannel network

The tests are commented out since they won't pass unless the wireguard
kernel module is loaded.
