### PR TITLE
Added new flag -iptables-resync

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -55,6 +55,7 @@ The following configuration illustrates the use of most options with `udp` backe
 --kube-subnet-mgr: Contact the Kubernetes API for subnet assignment instead of etcd.
 --iface="": interface to use (IP or name) for inter-host communication. Defaults to the interface for the default route on the machine. This can be specified multiple times to check each option in order. Returns the first match found.
 --iface-regex="": regex expression to match the first interface to use (IP or name) for inter-host communication. If unspecified, will default to the interface for the default route on the machine. This can be specified multiple times to check each regex in order. Returns the first match found. This option is superseded by the iface option and will only be used if nothing matches any option specified in the iface options.
+--iptables-resync=5: resync period for iptables rules, in seconds. Defaults to 5 seconds, if you see a large amount of contention for the iptables lock increasing this will probably help.
 --subnet-file=/run/flannel/subnet.env: filename where env variables (subnet and MTU values) will be written to.
 --subnet-lease-renew-margin=60: subnet lease renewal margin, in minutes.
 --ip-masq=false: setup IP masquerade for traffic destined for outside the flannel network. Flannel assumes that the default policy is ACCEPT in the NAT POSTROUTING chain.

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ type CmdLineOpts struct {
 	healthzPort            int
 	charonExecutablePath   string
 	charonViciUri          string
+	iptablesResyncSeconds  int
 }
 
 var (
@@ -124,6 +125,7 @@ func init() {
 	flannelFlags.BoolVar(&opts.version, "version", false, "print version and exit")
 	flannelFlags.StringVar(&opts.healthzIP, "healthz-ip", "0.0.0.0", "the IP address for healthz server to listen")
 	flannelFlags.IntVar(&opts.healthzPort, "healthz-port", 0, "the port for healthz server to listen(0 to disable)")
+	flannelFlags.IntVar(&opts.iptablesResyncSeconds, "iptables-resyc", 5, "resync period for iptables rules, in seconds")
 
 	// glog will log to tmp files by default. override so all entries
 	// can flow into journald (if running under systemd)
@@ -288,13 +290,13 @@ func main() {
 
 	// Set up ipMasq if needed
 	if opts.ipMasq {
-		go network.SetupAndEnsureIPTables(network.MasqRules(config.Network, bn.Lease()))
+		go network.SetupAndEnsureIPTables(network.MasqRules(config.Network, bn.Lease()), opts.iptablesResyncSeconds)
 	}
 
 	// Always enables forwarding rules. This is needed for Docker versions >1.13 (https://docs.docker.com/engine/userguide/networking/default_network/container-communication/#container-communication-between-hosts)
 	// In Docker 1.12 and earlier, the default FORWARD chain policy was ACCEPT.
 	// In Docker 1.13 and later, Docker sets the default policy of the FORWARD chain to DROP.
-	go network.SetupAndEnsureIPTables(network.ForwardRules(config.Network.String()))
+	go network.SetupAndEnsureIPTables(network.ForwardRules(config.Network.String()), opts.iptablesResyncSeconds)
 
 	if err := WriteSubnetFile(opts.subnetFile, config.Network, opts.ipMasq, bn); err != nil {
 		// Continue, even though it failed.

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -79,7 +79,7 @@ func ipTablesRulesExist(ipt IPTables, rules []IPTablesRule) (bool, error) {
 	return true, nil
 }
 
-func SetupAndEnsureIPTables(rules []IPTablesRule) {
+func SetupAndEnsureIPTables(rules []IPTablesRule, resyncPeriod int) {
 	ipt, err := iptables.New()
 	if err != nil {
 		// if we can't find iptables, give up and return
@@ -97,7 +97,7 @@ func SetupAndEnsureIPTables(rules []IPTablesRule) {
 			log.Errorf("Failed to ensure iptables rules: %v", err)
 		}
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(time.Duration(resyncPeriod) * time.Second)
 	}
 }
 

--- a/network/iptables_windows.go
+++ b/network/iptables_windows.go
@@ -39,6 +39,6 @@ func ForwardRules(flannelNetwork string) []IPTablesRule {
 	return nil
 }
 
-func SetupAndEnsureIPTables(rules []IPTablesRule) {
+func SetupAndEnsureIPTables(rules []IPTablesRule, resyncPeriod int) {
 
 }


### PR DESCRIPTION

## Description
Referenced issue: https://github.com/coreos/flannel/issues/933

This pull creates a flag that can be used to adjust the resync period of the ensure iptables routine. On a larger cluster with many services we found 5 seconds to be too aggressive and created too much iptables lock contention causing kube-proxy to fail to sync it's tables.

## Todos
- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
Adds new flag --iptables-resync, allows adjustment of IPTables "ensure" check. Expects an integer it will then multiply by seconds, defaults to 5. Guidance is to adjust this upwards if you see too much iptables lock contention.
```
