### PR TITLE
Log all the available interfaces when none were found

### DIFF
--- a/main.go
+++ b/main.go
@@ -474,7 +474,13 @@ func LookupExtIface(ifname string, ifregex string) (*backend.ExternalInterface, 
 
 		// Check that nothing was matched
 		if iface == nil {
-			return nil, fmt.Errorf("Could not match pattern %s to any of the available network interfaces", ifregex)
+			var availableFaces []string
+			for _, f := range ifaces {
+				ip, _ := ip.GetIfaceIP4Addr(&f) // We can safely ignore errors. We just won't log any ip
+				availableFaces = append(availableFaces, fmt.Sprintf("%s:%s", f.Name, ip))
+			}
+
+			return nil, fmt.Errorf("Could not match pattern %s to any of the available network interfaces (%s)", ifregex, strings.Join(availableFaces, ", "))
 		}
 	} else {
 		log.Info("Determining IP address of default interface")


### PR DESCRIPTION
## Description

I was trying to use the `--iface-regex` and my interface wasn't detected (for a dumb reason. I was adding quotation marks to the argument, and those were added to the string).
At first, I thought this was because my interfaces weren't properly detected by flannel though.

This improves the no detected interfaces error message to show all the available interfaces, name and IP address so it's clearer what the issue could be.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

I haven't written tests here because `main.go` doesn't have any, and setting up unit testing seems outside the purpose of this small PR.

## Release Note

```release-note
None required
```
