### PR TITLE
backend/udp: Use a /32 prefix for the flannel0 interface

### DIFF
--- a/backend/udp/udp_network_amd64.go
+++ b/backend/udp/udp_network_amd64.go
@@ -153,9 +153,15 @@ func configureIface(ifname string, ipn ip.IP4Net, mtu int) error {
 		return fmt.Errorf("failed to lookup interface %v", ifname)
 	}
 
-	err = netlink.AddrAdd(iface, &netlink.Addr{IPNet: ipn.ToIPNet(), Label: ""})
+	// Ensure that the device has a /32 address so that no broadcast routes are created.
+	// This IP is just used as a source address for host to workload traffic (so
+	// the return path for the traffic has an address on the flannel network to use as the destination)
+	ipnLocal := ipn
+	ipnLocal.PrefixLen = 32
+
+	err = netlink.AddrAdd(iface, &netlink.Addr{IPNet: ipnLocal.ToIPNet(), Label: ""})
 	if err != nil {
-		return fmt.Errorf("failed to add IP address %v to %v: %v", ipn.String(), ifname, err)
+		return fmt.Errorf("failed to add IP address %v to %v: %v", ipnLocal.String(), ifname, err)
 	}
 
 	err = netlink.LinkSetMTU(iface, mtu)


### PR DESCRIPTION
## Description
I discovered that bug #533 still affects my team, since the fix (#576) only applies to the vxlan backend, but the bug is also present in the udp backend. This pull requests fixes the same bug in the udp backend.

Specifically, I found that whichever host was assigned the zeroth subnet (172.18.0.0/24 out of 172.18.0.0/16 in our test cluster) would not be able to communicate from the host level to the container level of any other host, because the receiving host would think that a message from 172.18.0.0 was from the broadcast address. By changing the flannel interface to have 172.18.x.0/32 bound instead of 172.18.x.0/16, this problem was avoided.

I've deployed these changes to our test cluster, and the problem seems to be resolved without breaking anything else.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

Since this is a small bugfix, and the `udp` backend doesn't appear to have any existing unit tests, I'm assuming that I don't need to add any tests. Documentation also seems unnecessary.

## Release Note

```release-note
None required
```