### PR TITLE
Add link to flannel-node-annotator

### DIFF
--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -16,7 +16,7 @@ When you run pods, they will be allocated IP addresses from the pod network CIDR
 
 # Annotations
 
-*  `flannel.alpha.coreos.com/public-ip-overwrite`: Allows to overwrite the public IP of a node. Useful if the public IP can not determined from the node, e.G. because it is behind a NAT
+*  `flannel.alpha.coreos.com/public-ip-overwrite`: Allows to overwrite the public IP of a node. Useful if the public IP can not determined from the node, e.G. because it is behind a NAT. It can be automatically set to a nodes `ExternalIP` using the [flannel-node-annotator](https://github.com/alvaroaleman/flannel-node-annotator)
 
 ## Older versions of Kubernetes
 
@@ -28,7 +28,7 @@ If you see errors saying `found invalid field...` when you try to apply `kube-fl
 This file does not bundle RBAC permissions. If you need those, run
 * `kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel-rbac.yml`
 
-If you didn't apply the `kube-flannel-rbac.yml` manifest and you need to, you'll see errors in your flanneld logs about failing to connect. 
+If you didn't apply the `kube-flannel-rbac.yml` manifest and you need to, you'll see errors in your flanneld logs about failing to connect.
 * `Failed to create SubnetManager: error retrieving pod spec...`
 
 ## The flannel CNI plugin


### PR DESCRIPTION
## Description

This adds a link to the `flannel-node-annotator` which automatically sets a `flannel.alpha.coreos.com/public-ip-overwrite` annotation on all Kubernetes nodes that have an `ExternalIP` set.

## Todos
- [x] Documentation

## Release Note

```release-note
None required
```
