### PR TITLE
Fixed typo in arguments parser

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func init() {
 	flannelFlags.BoolVar(&opts.version, "version", false, "print version and exit")
 	flannelFlags.StringVar(&opts.healthzIP, "healthz-ip", "0.0.0.0", "the IP address for healthz server to listen")
 	flannelFlags.IntVar(&opts.healthzPort, "healthz-port", 0, "the port for healthz server to listen(0 to disable)")
-	flannelFlags.IntVar(&opts.iptablesResyncSeconds, "iptables-resyc", 5, "resync period for iptables rules, in seconds")
+	flannelFlags.IntVar(&opts.iptablesResyncSeconds, "iptables-resync", 5, "resync period for iptables rules, in seconds")
 
 	// glog will log to tmp files by default. override so all entries
 	// can flow into journald (if running under systemd)


### PR DESCRIPTION
## Description
This fixes a typo where the arguments parser does not match the usage documentation.

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Release note - There has not been a release since this typo was introduced, so no release note should be necessary.


## Release Note
```release-note
None required
```
