### PR TITLE
Make the iptables FORWARD chain rules optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ type CmdLineOpts struct {
 	charonExecutablePath   string
 	charonViciUri          string
 	iptablesResyncSeconds  int
+	iptablesForwardRules   bool
 }
 
 var (
@@ -126,6 +127,7 @@ func init() {
 	flannelFlags.StringVar(&opts.healthzIP, "healthz-ip", "0.0.0.0", "the IP address for healthz server to listen")
 	flannelFlags.IntVar(&opts.healthzPort, "healthz-port", 0, "the port for healthz server to listen(0 to disable)")
 	flannelFlags.IntVar(&opts.iptablesResyncSeconds, "iptables-resync", 5, "resync period for iptables rules, in seconds")
+	flannelFlags.BoolVar(&opts.iptablesForwardRules, "iptables-forward-rules", true, "add default accept rules to FORWARD chain in iptables")
 
 	// glog will log to tmp files by default. override so all entries
 	// can flow into journald (if running under systemd)
@@ -296,7 +298,9 @@ func main() {
 	// Always enables forwarding rules. This is needed for Docker versions >1.13 (https://docs.docker.com/engine/userguide/networking/default_network/container-communication/#container-communication-between-hosts)
 	// In Docker 1.12 and earlier, the default FORWARD chain policy was ACCEPT.
 	// In Docker 1.13 and later, Docker sets the default policy of the FORWARD chain to DROP.
-	go network.SetupAndEnsureIPTables(network.ForwardRules(config.Network.String()), opts.iptablesResyncSeconds)
+	if opts.iptablesForwardRules {
+		go network.SetupAndEnsureIPTables(network.ForwardRules(config.Network.String()), opts.iptablesResyncSeconds)
+	}
 
 	if err := WriteSubnetFile(opts.subnetFile, config.Network, opts.ipMasq, bn); err != nil {
 		// Continue, even though it failed.


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/4037, https://github.com/projectcalico/canal/issues/115, #938

## Description
Add a flag to allow users to specify whether they want to add the default `ACCEPT` traffic rules to the iptables `FORWARD` chain, which was introduced in Flannel release v0.9.1 to support Docker versions 1.13 and later (where docker sets the default policy on the `FORWARD` chain to drop).

Users may need to disable this behaviour in certain scenarios such as documented in #938, where used in conjunction with Calico (when `FELIX_CHAININSERTMODE` is set to `append`), as it breaks network policy behaviour.

**Environment Variable:** FLANNEL_IPTABLES_FORWARD_RULES
**Command Line Option:** iptables-forward-rules
**Default Value:** true (shouldn't break or modify existing behaviour)