### PR TITLE
Builds:Revert go version to 1.8.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 # Go version to use for builds
-GO_VERSION=1.9.2
+GO_VERSION=1.8.7
 
 # K8s version used for Makefile helpers
 K8S_VERSION=v1.6.6


### PR DESCRIPTION
Fix #977  
go v1.9.2 has this issue and flannel is involved. That cause some VMs cannot start flannel successfully.
https://github.com/golang/go/issues/22724
It has fixed in go v1.10.1
So i suggest revert go to 1.8.7
And i have test flannel built by 1.8.7 can operate on these VMs well.
