### PR TITLE
subnet/kube: Handle missed node deletions

### DIFF
--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -174,7 +174,19 @@ func newKubeSubnetManager(c clientset.Interface, sc *subnet.Config, nodeName str
 }
 
 func (ksm *kubeSubnetManager) handleAddLeaseEvent(et subnet.EventType, obj interface{}) {
-	n := obj.(*v1.Node)
+	n, ok := obj.(*v1.Node)
+	if !ok {
+		d, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Errorf("Unexpected object type: %#v", obj)
+			return
+		}
+		n, ok = d.Obj.(*v1.Node)
+		if !ok {
+			glog.Errorf("Unexpected object type: %#v", obj)
+			return
+		}
+	}
 	if s, ok := n.Annotations[subnetKubeManagedAnnotation]; !ok || s != "true" {
 		return
 	}


### PR DESCRIPTION
## Description

If the node controller misses the deletion of a node the DeltaFIFO will insert a tombstone object (DeletedFinalStateUnknown) with the last known view of the object. The current code will panic due to a failed type assertion to v1.Node.

This PR includes a fix for this panic by checking the result of the type assertion and attempting to extract the last know state from the tombstone.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
