### PR TITLE
Allow changing subnet/kube annotation prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ type CmdLineOpts struct {
 	version                bool
 	kubeSubnetMgr          bool
 	kubeApiUrl             string
+	kubeAnnotationPrefix   string
 	kubeConfigFile         string
 	iface                  flagSlice
 	ifaceRegex             flagSlice
@@ -121,6 +122,7 @@ func init() {
 	flannelFlags.BoolVar(&opts.ipMasq, "ip-masq", false, "setup IP masquerade rule for traffic destined outside of overlay network")
 	flannelFlags.BoolVar(&opts.kubeSubnetMgr, "kube-subnet-mgr", false, "contact the Kubernetes API for subnet assignment instead of etcd.")
 	flannelFlags.StringVar(&opts.kubeApiUrl, "kube-api-url", "", "Kubernetes API server URL. Does not need to be specified if flannel is running in a pod.")
+	flannelFlags.StringVar(&opts.kubeAnnotationPrefix, "kube-annotation-prefix", "flannel.alpha.coreos.com", `Kubernetes annotation prefix. Can contain single slash "/", otherwise it will be appended at the end.`)
 	flannelFlags.StringVar(&opts.kubeConfigFile, "kubeconfig-file", "", "kubeconfig file location. Does not need to be specified if flannel is running in a pod.")
 	flannelFlags.BoolVar(&opts.version, "version", false, "print version and exit")
 	flannelFlags.StringVar(&opts.healthzIP, "healthz-ip", "0.0.0.0", "the IP address for healthz server to listen")
@@ -155,7 +157,7 @@ func usage() {
 
 func newSubnetManager() (subnet.Manager, error) {
 	if opts.kubeSubnetMgr {
-		return kube.NewSubnetManager(opts.kubeApiUrl, opts.kubeConfigFile)
+		return kube.NewSubnetManager(opts.kubeApiUrl, opts.kubeConfigFile, opts.kubeAnnotationPrefix)
 	}
 
 	cfg := &etcdv2.EtcdConfig{

--- a/subnet/kube/annotations.go
+++ b/subnet/kube/annotations.go
@@ -1,4 +1,4 @@
-// Copyright 2016 flannel authors
+// Copyright 2018 flannel authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,12 @@ func newAnnotations(prefix string) (annotations, error) {
 		prefix += "-"
 	}
 
+	// matches is a regexp matching the format used by the kubernetes for
+	// annotations. Following rules apply:
+	//
+	//	- must start with FQDN - must contain at most one slash "/"
+	//	- must contain only lowercase letters, nubers, underscores,
+	//	  hyphens, dots and slash
 	matches, err := regexp.MatchString(`(?:[a-z0-9_-]+\.)+[a-z0-9_-]+/(?:[a-z0-9_-]+-)?$`, prefix)
 	if err != nil {
 		panic(err)

--- a/subnet/kube/annotations.go
+++ b/subnet/kube/annotations.go
@@ -1,0 +1,60 @@
+// Copyright 2016 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+type annotations struct {
+	SubnetKubeManaged        string
+	BackendData              string
+	BackendType              string
+	BackendPublicIP          string
+	BackendPublicIPOverwrite string
+}
+
+func newAnnotations(prefix string) (annotations, error) {
+	slashCnt := strings.Count(prefix, "/")
+	if slashCnt > 1 {
+		return annotations{}, errors.New("subnet/kube: prefix can contain at most single slash")
+	}
+	if slashCnt == 0 {
+		prefix += "/"
+	}
+	if !strings.HasSuffix(prefix, "/") && !strings.HasSuffix(prefix, "-") {
+		prefix += "-"
+	}
+
+	matches, err := regexp.MatchString(`(?:[a-z0-9_-]+\.)+[a-z0-9_-]+/(?:[a-z0-9_-]+-)?$`, prefix)
+	if err != nil {
+		panic(err)
+	}
+	if !matches {
+		return annotations{}, errors.New("subnet/kube: prefix must be in a format: fqdn/[0-9a-z-_]*")
+	}
+
+	a := annotations{
+		SubnetKubeManaged:        prefix + "kube-subnet-manager",
+		BackendData:              prefix + "backend-data",
+		BackendType:              prefix + "backend-type",
+		BackendPublicIP:          prefix + "public-ip",
+		BackendPublicIPOverwrite: prefix + "public-ip-overwrite",
+	}
+
+	return a, nil
+}

--- a/subnet/kube/annotations_test.go
+++ b/subnet/kube/annotations_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 flannel authors
+// Copyright 2018 flannel authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/subnet/kube/annotations_test.go
+++ b/subnet/kube/annotations_test.go
@@ -1,0 +1,96 @@
+// Copyright 2016 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import "testing"
+
+func Test_newAnnotations(t *testing.T) {
+	testCases := []struct {
+		prefix              string
+		expectedBackendType string
+		hasError            bool
+	}{
+		{
+			prefix:              "flannel.alpha.coreos.com",
+			expectedBackendType: "flannel.alpha.coreos.com/backend-type",
+		},
+		{
+			prefix:              "flannel.alpha.coreos.com/",
+			expectedBackendType: "flannel.alpha.coreos.com/backend-type",
+		},
+		{
+			prefix:              "flannel.alpha.coreos.com/prefix",
+			expectedBackendType: "flannel.alpha.coreos.com/prefix-backend-type",
+		},
+		{
+			prefix:              "flannel.alpha.coreos.com/prefix-",
+			expectedBackendType: "flannel.alpha.coreos.com/prefix-backend-type",
+		},
+		{
+			prefix:              "org.com",
+			expectedBackendType: "org.com/backend-type",
+		},
+		{
+			prefix:              "org9.com",
+			expectedBackendType: "org9.com/backend-type",
+		},
+		{
+			prefix:              "org.com/9",
+			expectedBackendType: "org.com/9-backend-type",
+		},
+		{
+			// Not a fqdn.
+			prefix:   "org",
+			hasError: true,
+		},
+		{
+			// Not a fqdn before /.
+			prefix:   "org/",
+			hasError: true,
+		},
+		{
+			// Not a fqdn before /.
+			prefix:   "org/prefix",
+			hasError: true,
+		},
+		{
+			// Uppercase letters.
+			prefix:   "org.COM",
+			hasError: true,
+		},
+		{
+			// Uppercase letters.
+			prefix:   "org.com/PREFIX",
+			hasError: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		as, err := newAnnotations(tc.prefix)
+
+		if err != nil && !tc.hasError {
+			t.Errorf("#%d: error = %s, want nil", i, err)
+			continue
+		}
+		if err == nil && tc.hasError {
+			t.Errorf("#%d: error = nil, want non-nil", i)
+			continue
+		}
+
+		if as.BackendType != tc.expectedBackendType {
+			t.Errorf("#%d: BackendType = %s, want %s", i, as.BackendType, tc.expectedBackendType)
+		}
+	}
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Fixes https://github.com/coreos/flannel/issues/804

It adds new `--kube-annotation-prefix` flag which defaults to `flannel.alpha.coreos.com` so the current behavior remains unchanged.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->
