### PR TITLE
Enable fully random masquerading ports

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:edge
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine
+FROM arm32v6/alpine:edge
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine
+FROM arm64v8/alpine:edge
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -48,11 +48,11 @@ func MasqRules(ipn ip.IP4Net, lease *subnet.Lease) []IPTablesRule {
 		// This rule makes sure we don't NAT traffic within overlay network (e.g. coming out of docker0)
 		{"nat", "POSTROUTING", []string{"-s", n, "-d", n, "-j", "RETURN"}},
 		// NAT if it's not multicast traffic
-		{"nat", "POSTROUTING", []string{"-s", n, "!", "-d", "224.0.0.0/4", "-j", "MASQUERADE"}},
+		{"nat", "POSTROUTING", []string{"-s", n, "!", "-d", "224.0.0.0/4", "-j", "MASQUERADE", "--random-fully"}},
 		// Prevent performing Masquerade on external traffic which arrives from a Node that owns the container/pod IP address
 		{"nat", "POSTROUTING", []string{"!", "-s", n, "-d", sn, "-j", "RETURN"}},
 		// Masquerade anything headed towards flannel from the host
-		{"nat", "POSTROUTING", []string{"!", "-s", n, "-d", n, "-j", "MASQUERADE"}},
+		{"nat", "POSTROUTING", []string{"!", "-s", n, "-d", n, "-j", "MASQUERADE", "--random-fully"}},
 	}
 }
 


### PR DESCRIPTION
## Description
There is a race condition in linux which can lead to packages being
dropped when many connections are established to the same address.

See this for more datail: https://tech.xing.com/a-reason-for-unexplained-connection-timeouts-on-kubernetes-docker-abd041cf7e02

This commit introduces the proposed workaround of enabling fully
randomized ports. Since this requires iptables 1.6.2, it requires using
alpine:edge until the next release.

See this for similar discussion in weave: https://github.com/weaveworks/weave/issues/3287