### PR TITLE
Clarify where the config is read from 

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -1,7 +1,8 @@
 # Configuration
 
-flannel reads its configuration from etcd.
+If the --kube-subnet-mgr argument is true, flannel reads its configuration from `/etc/kube-flannel/net-conf.json`.
 
+If the --kube-subnet-mgr argument is false, flannel reads its configuration from etcd.
 By default, it will read the configuration from `/coreos.com/network/config` (which can be overridden using `--etcd-prefix`).
 
 Use the `etcdctl` utility to set values in etcd.


### PR DESCRIPTION
Relevant when using --kube-subnet-mgr, e.g. when using the provided Kubernetes manifest.

## Description
- type of fix: documentation
- why this PR should be merged: save others from wasting their time dealing with etcd needlessly

## Release Note
```release-note
None required
```
