### PR TITLE
remove "list" typo from daemonset file

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -110,7 +110,7 @@ spec:
         args:
         - -f
         - /etc/kube-flannel/cni-conf.json
-        - /etc/cni/net.d/10-flannel.conflist
+        - /etc/cni/net.d/10-flannel.conf
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
There is a type in the deployment doc that writes the configMap settings to `/etc/cni/net.d/10-flannel.conflist` instead of /etc/cni/net.d/10-flannel.conf` where it needs to be. I noticed this after our HairPin settings were not enabled. After a lengthy investigation I was able to track it down to the Documentation file having an error:

https://raw.githubusercontent.com/coreos/flannel/v0.10.0/Documentation/kube-flannel.yml

If required I can include a more indepth example but from the diff it should be clear there is a typo.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
