### PR TITLE
Fix a typo: move “kubelet” out of the code block

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -73,7 +73,7 @@ You can check the podCidr for your nodes with one of the following two commands
 * `kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}'`
 * `kubectl get nodes -o template --template={{.spec.podCIDR}}`
 
-If your nodes do not have a podCIDR, then either use the `--pod-cidr kubelet` command-line option or the `--allocate-node-cidrs=true --cluster-cidr=<cidr>` controller-manager command-line options.
+If your nodes do not have a podCIDR, then either use the `--pod-cidr` kubelet command-line option or the `--allocate-node-cidrs=true --cluster-cidr=<cidr>` controller-manager command-line options.
 
 If `kubeadm` is being used then pass `--pod-network-cidr=10.244.0.0/16` to `kubeadm init` which will ensure that all nodes are automatically assigned a `podCIDR`.
 


### PR DESCRIPTION
## Description

Fix a typo in the troubleshooting docs.

I have a little experience with Kubernetes, so `--pod-cidr kubelet` made me think that `kubelet` is the `--pod-cidr` value.

<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos

Nothing

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
