### PR TITLE
Deploy Flannel with unprivileged PSP

### DIFF
--- a/Documentation/kube-flannel-old.yaml
+++ b/Documentation/kube-flannel-old.yaml
@@ -1,60 +1,9 @@
 ---
-apiVersion: extensions/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: psp.flannel.unprivileged
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-spec:
-  privileged: false
-  volumes:
-    - configMap
-    - secret
-    - emptyDir
-    - hostPath
-  allowedHostPaths:
-    - pathPrefix: "/etc/cni/net.d"
-    - pathPrefix: "/etc/kube-flannel"
-    - pathPrefix: "/run/flannel"
-  readOnlyRootFilesystem: false
-  # Users and groups
-  runAsUser:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  fsGroup:
-    rule: RunAsAny
-  # Privilege Escalation
-  allowPrivilegeEscalation: false
-  defaultAllowPrivilegeEscalation: false
-  # Capabilities
-  allowedCapabilities: ['NET_ADMIN']
-  defaultAddCapabilities: []
-  requiredDropCapabilities: []
-  # Host namespaces
-  hostPID: false
-  hostIPC: false
-  hostNetwork: true
-  hostPorts:
-  - min: 0
-    max: 65535
-  # SELinux
-  seLinux:
-    # SELinux is unsed in CaaSP
-    rule: 'RunAsAny'
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: flannel
 rules:
-  - apiGroups: ['extensions']
-    resources: ['podsecuritypolicies']
-    verbs: ['use']
-    resourceNames: ['psp.flannel.unprivileged']
   - apiGroups:
       - ""
     resources:
@@ -154,7 +103,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-amd64
+        image: quay.io/coreos/flannel:v0.11.0-amd64
         command:
         - cp
         args:
@@ -168,7 +117,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-amd64
+        image: quay.io/coreos/flannel:v0.11.0-amd64
         command:
         - /opt/bin/flanneld
         args:
@@ -182,9 +131,7 @@ spec:
             cpu: "100m"
             memory: "50Mi"
         securityContext:
-          privileged: false
-          capabilities:
-             add: ["NET_ADMIN"]
+          privileged: true
         env:
         - name: POD_NAME
           valueFrom:
@@ -196,13 +143,13 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
         - name: run
-          mountPath: /run/flannel
+          mountPath: /run
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       volumes:
         - name: run
           hostPath:
-            path: /run/flannel
+            path: /run
         - name: cni
           hostPath:
             path: /etc/cni/net.d
@@ -234,7 +181,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-arm64
+        image: quay.io/coreos/flannel:v0.11.0-arm64
         command:
         - cp
         args:
@@ -248,7 +195,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-arm64
+        image: quay.io/coreos/flannel:v0.11.0-arm64
         command:
         - /opt/bin/flanneld
         args:
@@ -262,9 +209,7 @@ spec:
             cpu: "100m"
             memory: "50Mi"
         securityContext:
-          privileged: false
-          capabilities:
-             add: ["NET_ADMIN"]
+          privileged: true
         env:
         - name: POD_NAME
           valueFrom:
@@ -276,13 +221,13 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
         - name: run
-          mountPath: /run/flannel
+          mountPath: /run
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       volumes:
         - name: run
           hostPath:
-            path: /run/flannel
+            path: /run
         - name: cni
           hostPath:
             path: /etc/cni/net.d
@@ -314,7 +259,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-arm
+        image: quay.io/coreos/flannel:v0.11.0-arm
         command:
         - cp
         args:
@@ -328,7 +273,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-arm
+        image: quay.io/coreos/flannel:v0.11.0-arm
         command:
         - /opt/bin/flanneld
         args:
@@ -342,9 +287,7 @@ spec:
             cpu: "100m"
             memory: "50Mi"
         securityContext:
-          privileged: false
-          capabilities:
-             add: ["NET_ADMIN"]
+          privileged: true
         env:
         - name: POD_NAME
           valueFrom:
@@ -356,13 +299,13 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
         - name: run
-          mountPath: /run/flannel
+          mountPath: /run
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       volumes:
         - name: run
           hostPath:
-            path: /run/flannel
+            path: /run
         - name: cni
           hostPath:
             path: /etc/cni/net.d
@@ -394,7 +337,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-ppc64le
+        image: quay.io/coreos/flannel:v0.11.0-ppc64le
         command:
         - cp
         args:
@@ -408,7 +351,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-ppc64le
+        image: quay.io/coreos/flannel:v0.11.0-ppc64le
         command:
         - /opt/bin/flanneld
         args:
@@ -422,9 +365,7 @@ spec:
             cpu: "100m"
             memory: "50Mi"
         securityContext:
-          privileged: false
-          capabilities:
-             add: ["NET_ADMIN"]
+          privileged: true
         env:
         - name: POD_NAME
           valueFrom:
@@ -436,13 +377,13 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
         - name: run
-          mountPath: /run/flannel
+          mountPath: /run
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       volumes:
         - name: run
           hostPath:
-            path: /run/flannel
+            path: /run
         - name: cni
           hostPath:
             path: /etc/cni/net.d
@@ -474,7 +415,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-s390x
+        image: quay.io/coreos/flannel:v0.11.0-s390x
         command:
         - cp
         args:
@@ -488,7 +429,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-s390x
+        image: quay.io/coreos/flannel:v0.11.0-s390x
         command:
         - /opt/bin/flanneld
         args:
@@ -502,9 +443,7 @@ spec:
             cpu: "100m"
             memory: "50Mi"
         securityContext:
-          privileged: false
-          capabilities:
-             add: ["NET_ADMIN"]
+          privileged: true
         env:
         - name: POD_NAME
           valueFrom:
@@ -516,13 +455,13 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
         - name: run
-          mountPath: /run/flannel
+          mountPath: /run
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       volumes:
         - name: run
           hostPath:
-            path: /run/flannel
+            path: /run
         - name: cni
           hostPath:
             path: /etc/cni/net.d

--- a/dist/functional-test-k8s.sh
+++ b/dist/functional-test-k8s.sh
@@ -6,7 +6,7 @@ ETCD_LOCATION="${ETCD_LOCATION:-etcd}"
 FLANNEL_NET="${FLANNEL_NET:-10.10.0.0/16}"
 TAG=`git describe --tags --dirty`
 FLANNEL_DOCKER_IMAGE="${FLANNEL_DOCKER_IMAGE:-quay.io/coreos/flannel:$TAG}"
-K8S_VERSION="${K8S_VERSION:-1.7.6}"
+K8S_VERSION="${K8S_VERSION:-1.13.2}"
 HYPERKUBE_IMG="gcr.io/google_containers/hyperkube-${ARCH}"
 
 docker_ip=$(ip -o -f inet addr show docker0 | grep -Po 'inet \K[\d.]+')


### PR DESCRIPTION
Flannel is running in privileged mode, and is using the root user,
therefore if the container is compromised, an attacker will
inherit that level of access. An attacker compromising the flannel
container will have full root access to the host system, and access
to all secrets and containers hosted on the system.

This PR makes sure that flannel runs in unprivileged mode.

This is done by changing the flannel manifests and also adding
a new PSP policy that disables both privilege mode and privilege
escallation.

The new PSP activates 'NET_ADMIN' capability, hostNetwork
and allowedHostPaths.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
