### PR TITLE
kube-flannel.yaml: bump images to 0.11.0

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -103,7 +103,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-amd64
+        image: quay.io/coreos/flannel:v0.11.0-amd64
         command:
         - cp
         args:
@@ -117,7 +117,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-amd64
+        image: quay.io/coreos/flannel:v0.11.0-amd64
         command:
         - /opt/bin/flanneld
         args:
@@ -181,7 +181,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-arm64
+        image: quay.io/coreos/flannel:v0.11.0-arm64
         command:
         - cp
         args:
@@ -195,7 +195,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-arm64
+        image: quay.io/coreos/flannel:v0.11.0-arm64
         command:
         - /opt/bin/flanneld
         args:
@@ -259,7 +259,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-arm
+        image: quay.io/coreos/flannel:v0.11.0-arm
         command:
         - cp
         args:
@@ -273,7 +273,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-arm
+        image: quay.io/coreos/flannel:v0.11.0-arm
         command:
         - /opt/bin/flanneld
         args:
@@ -337,7 +337,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-ppc64le
+        image: quay.io/coreos/flannel:v0.11.0-ppc64le
         command:
         - cp
         args:
@@ -351,7 +351,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-ppc64le
+        image: quay.io/coreos/flannel:v0.11.0-ppc64le
         command:
         - /opt/bin/flanneld
         args:
@@ -415,7 +415,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-s390x
+        image: quay.io/coreos/flannel:v0.11.0-s390x
         command:
         - cp
         args:
@@ -429,7 +429,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.10.0-s390x
+        image: quay.io/coreos/flannel:v0.11.0-s390x
         command:
         - /opt/bin/flanneld
         args:


### PR DESCRIPTION
## Description
looks like 0.11.0 was tagged with 0.10.0 images.
use the 0.11.0 tag as the images are already up:
https://quay.io/repository/coreos/flannel?tab=tags

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
