### PR TITLE
clean redundant code in building kubernetes config

### DIFF
--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -68,17 +68,12 @@ func NewSubnetManager(apiUrl, kubeconfig, prefix string) (subnet.Manager, error)
 
 	var cfg *rest.Config
 	var err error
-	// Use out of cluster config if the URL or kubeconfig have been specified. Otherwise use incluster config.
-	if apiUrl != "" || kubeconfig != "" {
-		cfg, err = clientcmd.BuildConfigFromFlags(apiUrl, kubeconfig)
-		if err != nil {
-			return nil, fmt.Errorf("unable to create k8s config: %v", err)
-		}
-	} else {
-		cfg, err = rest.InClusterConfig()
-		if err != nil {
-			return nil, fmt.Errorf("unable to initialize inclusterconfig: %v", err)
-		}
+	// Try to build kubernetes config from a master url or a kubeconfig filepath. If neither masterUrl
+	// or kubeconfigPath are passed in we fall back to inClusterConfig. If inClusterConfig fails,
+	// we fallback to the default config.
+	cfg, err = clientcmd.BuildConfigFromFlags(apiUrl, kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("fail to create kubernetes config: %v", err)
 	}
 
 	c, err := clientset.NewForConfig(cfg)


### PR DESCRIPTION
## Description

function [BuildConfigFromFlags](https://github.com/coreos/flannel/blob/ba49cd4c1e49d566da4a08b370384ce8ced0c0e3/vendor/k8s.io/client-go/tools/clientcmd/client_config.go#L515) will build kubernetes config from masterURL or kubeconfig filepath firstly, if both are empty, it will fall back to build in-cluster config, if fails again, it will fall back to default config. So I think the origin codes for building kubernetes config are redundant and need some clean.

```release-note
None required
```
