### PR TITLE
add cni version to cni-conf yaml

### DIFF
--- a/Documentation/k8s-manifests/kube-flannel-legacy.yml
+++ b/Documentation/k8s-manifests/kube-flannel-legacy.yml
@@ -17,6 +17,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.3.1",
       "type": "flannel",
       "delegate": {
         "hairpinMode": true,

--- a/Documentation/kube-flannel-aliyun.yml
+++ b/Documentation/kube-flannel-aliyun.yml
@@ -55,6 +55,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.3.1",
       "type": "flannel",
       "delegate": {
         "hairpinMode": true,

--- a/Documentation/kube-flannel-old.yaml
+++ b/Documentation/kube-flannel-old.yaml
@@ -55,6 +55,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.3.1",
       "plugins": [
         {
           "type": "flannel",

--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -106,6 +106,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.3.1",
       "plugins": [
         {
           "type": "flannel",

--- a/Documentation/minikube.yml
+++ b/Documentation/minikube.yml
@@ -20,6 +20,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.3.1",
       "type": "flannel",
       "delegate": {
         "hairpinMode": true,


### PR DESCRIPTION
This PR adds the cni version to the cni-conf.yaml inside the kube-flannel-cfg configmap

This PR fixes an issue we latest multus version.
Multus is unable to call the cni delete function because the cni version is not configured.

Because of this issue pod addresses are not released

Error from pod:
```
Warning  FailedKillPod  8s     kubelet, node01    error killing pod: failed to "KillPodSandbox" for "cca49d68-758d-11e9-b08c-525500d15501" with KillPodSandboxError: "rpc error: code = Unknown desc = NetworkPlugin cni failed to teardown pod \"pod-example_default\" network: Multus: error in invoke Conflist Del - \"cbr0\": error in getting result from DelNetworkList: failed to convert major version part \"\": strconv.Atoi: parsing \"\": invalid syntax"

```

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
