### PR TITLE
main.go: add the "net-config-path" flag

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -58,6 +58,7 @@ The following configuration illustrates the use of most options with `udp` backe
 --iface-regex="": regex expression to match the first interface to use (IP or name) for inter-host communication. If unspecified, will default to the interface for the default route on the machine. This can be specified multiple times to check each regex in order. Returns the first match found. This option is superseded by the iface option and will only be used if nothing matches any option specified in the iface options.
 --iptables-resync=5: resync period for iptables rules, in seconds. Defaults to 5 seconds, if you see a large amount of contention for the iptables lock increasing this will probably help.
 --subnet-file=/run/flannel/subnet.env: filename where env variables (subnet and MTU values) will be written to.
+--net-config-path=/etc/kube-flannel/net-conf.json: path to the network configuration file to use
 --subnet-lease-renew-margin=60: subnet lease renewal margin, in minutes.
 --ip-masq=false: setup IP masquerade for traffic destined for outside the flannel network. Flannel assumes that the default policy is ACCEPT in the NAT POSTROUTING chain.
 -v=0: log level for V logs. Set to 1 to see messages related to data path.

--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -50,8 +50,6 @@ var (
 const (
 	resyncPeriod              = 5 * time.Minute
 	nodeControllerSyncTimeout = 10 * time.Minute
-
-	netConfPath = "/etc/kube-flannel/net-conf.json"
 )
 
 type kubeSubnetManager struct {
@@ -64,7 +62,7 @@ type kubeSubnetManager struct {
 	events         chan subnet.Event
 }
 
-func NewSubnetManager(apiUrl, kubeconfig, prefix string) (subnet.Manager, error) {
+func NewSubnetManager(apiUrl, kubeconfig, prefix, netConfPath string) (subnet.Manager, error) {
 
 	var cfg *rest.Config
 	var err error


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Add the flag "net-config-path" that holds the path
for the network configuration.

Set the default value to "/etc/kube-flannel/net-conf.json".

## Todos
- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
add the "net-config-path" CLI flag (set to "/etc/kube-flannel/net-conf.json" by default)
```

/assign @ksubrmnn 
/area configuration
/kind enhancement
