### PR TITLE
Fix up: missing wireguard-tools, build error

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -5,7 +5,7 @@ LABEL maintainer="Tom Denham <tom@tigera.io>"
 ENV FLANNEL_ARCH=amd64
 
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
-RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -6,7 +6,7 @@ ENV FLANNEL_ARCH=arm
 
 ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
-RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -6,7 +6,7 @@ ENV FLANNEL_ARCH=arm64
 
 ADD dist/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
-RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -6,7 +6,7 @@ ENV FLANNEL_ARCH=ppc64le
 
 ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
-RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -6,7 +6,7 @@ ENV FLANNEL_ARCH=s390x
 
 ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
-RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 


### PR DESCRIPTION
## Description
I made a PR that fixed Dcokerfile missing `wireguard-tools `,so it can't build.
```bash
Step 5/8 : RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 ---> Running in 8c2c5b2100fe
fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz

ERROR: unsatisfiable constraints:
  wireguard-tools (missing):
    required by: world[wireguard-tools]
The command '/bin/sh -c apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing' returned a non-zero code: 1
```
`wireguard-tools `  has been modified the repository from ` testing `to  `community` 
[alpinelinux pkg query ](https://pkgs.alpinelinux.org/packages?name=wireguard-tools&branch=edge&repo=testing&arch=x86_64)

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
