### PR TITLE
Make VXLAN device learning attribute configurable

### DIFF
--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -35,6 +35,7 @@ type vxlanDeviceAttrs struct {
 	vtepAddr  net.IP
 	vtepPort  int
 	gbp       bool
+	learning  bool
 }
 
 type vxlanDevice struct {
@@ -51,7 +52,7 @@ func newVXLANDevice(devAttrs *vxlanDeviceAttrs) (*vxlanDevice, error) {
 		VtepDevIndex: devAttrs.vtepIndex,
 		SrcAddr:      devAttrs.vtepAddr,
 		Port:         devAttrs.vtepPort,
-		Learning:     false,
+		Learning:     devAttrs.learning,
 		GBP:          devAttrs.gbp,
 	}
 

--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -107,6 +107,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg sync.WaitGroup, 
 		VNI           int
 		Port          int
 		GBP           bool
+		Learning      bool
 		DirectRouting bool
 	}{
 		VNI: defaultVNI,
@@ -117,7 +118,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg sync.WaitGroup, 
 			return nil, fmt.Errorf("error decoding VXLAN backend config: %v", err)
 		}
 	}
-	log.Infof("VXLAN config: VNI=%d Port=%d GBP=%v DirectRouting=%v", cfg.VNI, cfg.Port, cfg.GBP, cfg.DirectRouting)
+	log.Infof("VXLAN config: VNI=%d Port=%d GBP=%v Learning=%v DirectRouting=%v", cfg.VNI, cfg.Port, cfg.GBP, cfg.Learning, cfg.DirectRouting)
 
 	devAttrs := vxlanDeviceAttrs{
 		vni:       uint32(cfg.VNI),
@@ -126,6 +127,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg sync.WaitGroup, 
 		vtepAddr:  be.extIface.IfaceAddr,
 		vtepPort:  cfg.Port,
 		gbp:       cfg.GBP,
+		learning:  cfg.Learning,
 	}
 
 	dev, err := newVXLANDevice(&devAttrs)


### PR DESCRIPTION
allow user to configure VXLAN device learning attribute

## Description

address https://github.com/coreos/flannel/issues/1150
In some use case like BIGIP k8s controller integration with flannel vxlan, k8s node VTEP/POD ARP may needs to be populated on BIGIP as dynamic ARP/FDB record as result of dynamic ARP request/ARP reply mechanism, the learning attribute is required to make it work as tested in lab, thus the pull request to make learning attribute configurable by users.



## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
