### PR TITLE
iptables: handle errors that prevent rule deletes

### DIFF
--- a/network/iptables_test.go
+++ b/network/iptables_test.go
@@ -16,8 +16,10 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/coreos/flannel/pkg/ip"
@@ -32,7 +34,32 @@ func lease() *subnet.Lease {
 }
 
 type MockIPTables struct {
-	rules []IPTablesRule
+	rules    []IPTablesRule
+	t        *testing.T
+	failures map[string]*MockIPTablesError
+}
+
+type MockIPTablesError struct {
+	notExist bool
+}
+
+func (mock *MockIPTablesError) IsNotExist() bool {
+	return mock.notExist
+}
+
+func (mock *MockIPTablesError) Error() string {
+	return fmt.Sprintf("IsNotExist: %v", !mock.notExist)
+}
+
+func (mock *MockIPTables) failDelete(table string, chain string, rulespec []string, notExist bool) {
+
+	if mock.failures == nil {
+		mock.failures = make(map[string]*MockIPTablesError)
+	}
+	key := table + chain + strings.Join(rulespec, "")
+	mock.failures[key] = &MockIPTablesError{
+		notExist: notExist,
+	}
 }
 
 func (mock *MockIPTables) ruleIndex(table string, chain string, rulespec []string) int {
@@ -46,6 +73,12 @@ func (mock *MockIPTables) ruleIndex(table string, chain string, rulespec []strin
 
 func (mock *MockIPTables) Delete(table string, chain string, rulespec ...string) error {
 	var ruleIndex = mock.ruleIndex(table, chain, rulespec)
+	key := table + chain + strings.Join(rulespec, "")
+	reason := mock.failures[key]
+	if reason != nil {
+		return reason
+	}
+
 	if ruleIndex != -1 {
 		mock.rules = append(mock.rules[:ruleIndex], mock.rules[ruleIndex+1:]...)
 	}
@@ -69,7 +102,7 @@ func (mock *MockIPTables) AppendUnique(table string, chain string, rulespec ...s
 }
 
 func TestDeleteRules(t *testing.T) {
-	ipt := &MockIPTables{}
+	ipt := &MockIPTables{t: t}
 	setupIPTables(ipt, MasqRules(ip.IP4Net{}, lease()))
 	if len(ipt.rules) != 4 {
 		t.Errorf("Should be 4 masqRules, there are actually %d: %#v", len(ipt.rules), ipt.rules)
@@ -80,16 +113,44 @@ func TestDeleteRules(t *testing.T) {
 	}
 }
 
-func TestEnsureRules(t *testing.T) {
-	// If any masqRules are missing, they should be all deleted and recreated in the correct order
-	ipt_correct := &MockIPTables{}
+func TestEnsureRulesError(t *testing.T) {
+	// If an error prevents a rule from being deleted, ensureIPTables should leave the rules as is
+	// rather than potentially re-appending rules in an incorrect order
+	ipt_correct := &MockIPTables{t: t}
 	setupIPTables(ipt_correct, MasqRules(ip.IP4Net{}, lease()))
 	// setup a mock instance where we delete some masqRules and run `ensureIPTables`
-	ipt_recreate := &MockIPTables{}
+	ipt_recreate := &MockIPTables{t: t}
 	setupIPTables(ipt_recreate, MasqRules(ip.IP4Net{}, lease()))
 	ipt_recreate.rules = ipt_recreate.rules[0:2]
-	ensureIPTables(ipt_recreate, MasqRules(ip.IP4Net{}, lease()))
+
+	rule := ipt_recreate.rules[1]
+	ipt_recreate.failDelete(rule.table, rule.chain, rule.rulespec, false)
+	err := ensureIPTables(ipt_recreate, MasqRules(ip.IP4Net{}, lease()))
+	if err == nil {
+		t.Errorf("ensureIPTables should have failed but did not.")
+	}
+
+	if len(ipt_recreate.rules) == len(ipt_correct.rules) {
+		t.Errorf("ensureIPTables should not have completed.")
+	}
+}
+
+func TestEnsureRules(t *testing.T) {
+	// If any masqRules are missing, they should be all deleted and recreated in the correct order
+	ipt_correct := &MockIPTables{t: t}
+	setupIPTables(ipt_correct, MasqRules(ip.IP4Net{}, lease()))
+	// setup a mock instance where we delete some masqRules and run `ensureIPTables`
+	ipt_recreate := &MockIPTables{t: t}
+	setupIPTables(ipt_recreate, MasqRules(ip.IP4Net{}, lease()))
+	ipt_recreate.rules = ipt_recreate.rules[0:2]
+	// set up a normal error that iptables returns when deleting a rule that is already gone
+	deletedRule := ipt_correct.rules[3]
+	ipt_recreate.failDelete(deletedRule.table, deletedRule.chain, deletedRule.rulespec, true)
+	err := ensureIPTables(ipt_recreate, MasqRules(ip.IP4Net{}, lease()))
+	if err != nil {
+		t.Errorf("ensureIPTables should have completed without errors")
+	}
 	if !reflect.DeepEqual(ipt_recreate.rules, ipt_correct.rules) {
-		t.Errorf("iptables masqRules after ensureIPTables are incorrected. Expected: %#v, Actual: %#v", ipt_recreate.rules, ipt_correct.rules)
+		t.Errorf("iptables masqRules after ensureIPTables are incorrect. Expected: %#v, Actual: %#v", ipt_recreate.rules, ipt_correct.rules)
 	}
 }


### PR DESCRIPTION
Fixes #1146

## Description

The cause of the incorrect order of Flannel's rules in #1146 was found to be a case where an error occurs on deleting a rule and Flannel ignores the error and assumes the rule was already deleted.  As a result, the remaining rules are re-appended after the rule that could not be deleted, possibly causing them to be in the wrong order.  This change stops deleting additional rules on error and waits for the next execution of the reconciliation loop to correct the rules (assuming that the error deleting the rule was transient).

Type: Bug fix
Testing: In addition to the unit test, this has been tested as a patch on 0.9.1 (deployed on Kubernetes 1.13) where I verified that the error message for failing to teardown did get logged and that the rules on that host remained in the correct order.
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
