### PR TITLE
Add cniVersion to general CNI plugin configuration.

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -105,6 +105,7 @@ metadata:
 data:
   cni-conf.json: |
     {
+      "cniVersion": "0.2.0",
       "name": "cbr0",
       "plugins": [
         {


### PR DESCRIPTION
The configuration schema version is required to ensure compatibility.
Some implementations (CRI-O) require the field to be set.

Closes #1173.

## Description
The configmap in the general manifest at `./Documentation/kube-flannel.yml` now specifies the `cniVersion`. This makes the CRI-O error described in #1173 disappear.  

Please note that the following files also don't specify the `cniVersion` but I left them untouched since I am not sure which version would be appropriate since they are either legacy or for a particular environment which I am not running currently to test it:
* `./Documentation/kube-flannel-aliyun.yml`
* `./Documentation/kube-flannel-old.yaml`
* `./Documentation/k8s-manifests/kube-flannel-legacy.yml`
* `./Documentation/minikube.yml`