### PR TITLE
Support Kubernetes 1.16 and Linkerd

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -31,7 +31,7 @@ spec:
   allowPrivilegeEscalation: false
   defaultAllowPrivilegeEscalation: false
   # Capabilities
-  allowedCapabilities: ['NET_ADMIN']
+  allowedCapabilities: ['NET_ADMIN','NET_RAW']
   defaultAddCapabilities: []
   requiredDropCapabilities: []
   # Host namespaces
@@ -106,6 +106,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.2.0",
       "plugins": [
         {
           "type": "flannel",


### PR DESCRIPTION
## Description
added "cniVersion": "0.2.0" to make it work in Kubernetes 1.16
added NET_RAW support to PodSecurityPolicy to support Linkerd proxy injection

## Release Note
I have only tested this on two clusters built on Kubernetes 1.16.  It's worked for me in all cases.  Linkerd fix was tested with edge 19.9.3 (stable 2.5 does not work on Kubernetes 1.16)

I'm not sure if this is a "proper" fix, this is just what worked for me (twice).