### PR TITLE
Add cniVersion to kube-flannel.yml

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -106,6 +106,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.3.1",
       "plugins": [
         {
           "type": "flannel",


### PR DESCRIPTION
## Description
Seems that k8s 1.16 needs a cniVersion specified in the cni config file. https://github.com/kubernetes/kubernetes/issues/82997  
Current kube-flannel.yml does not have it, this PR adds it.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
