### PR TITLE
documentation: add cniversion to kube-flannel.yml

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -106,6 +106,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.2.0",
       "plugins": [
         {
           "type": "flannel",


### PR DESCRIPTION
## Description
- k8s 1.16 now requires cniversion in cni-conf.json.
- setting cni version to 0.2.0

Fixes #1185, #1178, #1173

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
None required
```
