### PR TITLE
add cniVersion in Documentation/kube-flannel.yml

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -105,6 +105,7 @@ metadata:
 data:
   cni-conf.json: |
     {
+      "cniVersion": "0.2.0",
       "name": "cbr0",
       "plugins": [
         {


### PR DESCRIPTION
## add cniVersion in Documentation/kube-flannel.yml
- type of fix: documentation
- why this PR should be merged: kubernetes 1.6 CNI requires "cniVersion"
- testing done: manual, without "cniVersion", cni failed to read /etc/cni/net.d/10-flannel.conflist; with "cniVersion" cni succeed
- components: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
