### PR TITLE
Updates e2e test go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ endif
 		-u $(shell id -u):$(shell id -g) \
 		-v $(CURDIR):/go/src/github.com/coreos/flannel:ro \
 		-v $(CURDIR)/dist:/go/src/github.com/coreos/flannel/dist \
-		golang:1.8.3 /bin/bash -c '\
+		golang:$(GO_VERSION) /bin/bash -c '\
 		cd /go/src/github.com/coreos/flannel && \
 		CGO_ENABLED=1 make -e dist/flanneld && \
 		mv dist/flanneld dist/flanneld-$(ARCH)'


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
- bugfix
- Makefile

e2e test builds are using go version 1.8.3 instead of GO_VERSION provided in Makefile.


