### PR TITLE
Update bhendo/go-powershell

### DIFF
--- a/vendor/github.com/bhendo/go-powershell/shell.go
+++ b/vendor/github.com/bhendo/go-powershell/shell.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gorillalabs/go-powershell/backend"
-	"github.com/gorillalabs/go-powershell/utils"
+	"github.com/bhendo/go-powershell/backend"
+	"github.com/bhendo/go-powershell/utils"
 	"github.com/juju/errors"
 )
 


### PR DESCRIPTION
'gorillalabs/go-powershell' no longer exists. It breaks windows build of flannel.

##### Reference
- https://github.com/bhendo/go-powershell/pull/1