### PR TITLE
Fix: prevent e2e tests to reuse network config of previous tests

### DIFF
--- a/dist/functional-test.sh
+++ b/dist/functional-test.sh
@@ -45,6 +45,7 @@ setup() {
 
 teardown() {
     docker rm -f flannel-e2e-test-flannel1 flannel-e2e-test-flannel2 flannel-e2e-test-flannel1-iperf flannel-host1 flannel-host2 > /dev/null 2>&1
+    docker run --rm $ETCDCTL_IMG etcdctl --endpoints=$etcd_endpt rm /coreos.com/network/config > /dev/null 2>&1
 }
 
 write_config_etcd() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
- bug fix
- e2e-tests teardown

If you look into the output of iperf after running e2e-tests ([travis](https://travis-ci.org/coreos/flannel/builds/593646073)) you'll notice that ipsec is fast and vxlan is slow. I inspected this further and noticed that an e2e-test is always using the network config of the previous test. The tests assuming that flannel waits until etcd is written. But because the old network config is not removed flannel starts using that configuration. This PR fixes this behaviour and removes etcd network config after each test is run.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
