### PR TITLE
ipsec: ensure charon daemon spawns before acquiring a subnet

### DIFF
--- a/backend/ipsec/ipsec.go
+++ b/backend/ipsec/ipsec.go
@@ -95,6 +95,11 @@ func (be *IPSECBackend) RegisterNetwork(
 
 	log.Infof("IPSec config: UDPEncap=%v ESPProposal=%s", cfg.UDPEncap, cfg.ESPProposal)
 
+	ikeDaemon, err := NewCharonIKEDaemon(ctx, wg, cfg.ESPProposal)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CharonIKEDaemon struct: %v", err)
+	}
+
 	attrs := subnet.LeaseAttrs{
 		PublicIP:    ip.FromIP(be.extIface.ExtAddr),
 		BackendType: "ipsec",
@@ -110,11 +115,6 @@ func (be *IPSECBackend) RegisterNetwork(
 
 	default:
 		return nil, fmt.Errorf("failed to acquire lease: %v", err)
-	}
-
-	ikeDaemon, err := NewCharonIKEDaemon(ctx, wg, cfg.ESPProposal)
-	if err != nil {
-		return nil, fmt.Errorf("error creating CharonIKEDaemon struct: %v", err)
 	}
 
 	return newNetwork(be.sm, be.extIface, cfg.UDPEncap, cfg.PSK, ikeDaemon, l)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
I wanted to add a new dependency to flannel which is requiring to be build with go >= 12.
I run into the problem that building flannel with go >=11 will break the e2e-tests.
The messages is ```panic: sync: WaitGroup misuse: Add called concurrently with Wait``` in ipsec backend.

```
I1021 19:59:52.286792       1 main.go:518] Determining IP address of default interface
I1021 19:59:52.286939       1 main.go:531] Using interface with name eth0 and address 172.17.0.4
I1021 19:59:52.286949       1 main.go:548] Defaulting external address to interface address (172.17.0.4)
I1021 19:59:52.287009       1 main.go:246] Created subnet manager: Etcd Local Manager with Previous Subnet: None
I1021 19:59:52.287017       1 main.go:249] Installing signal handlers
I1021 19:59:52.288097       1 main.go:390] Found network config - Backend type: ipsec
I1021 19:59:52.288118       1 ipsec.go:96] IPSec config: UDPEncap=false ESPProposal=aes128gcm16-sha256-prfsha256-ecp256
I1021 19:59:52.289754       1 local_manager.go:147] Found lease (10.50.91.0/24) for current IP (172.17.0.4), reusing
I1021 19:59:52.290725       1 handle_charon.go:57] Charon daemon started
00[DMN] Starting IKE charon daemon (strongSwan 5.7.2, Linux 5.3.7-arch1-1-ARCH, x86_64)
panic: sync: WaitGroup misuse: Add called concurrently with Wait

goroutine 1 [running]:
sync.(*WaitGroup).Add(0xc0000d85b4, 0x1)
        /usr/local/go/src/sync/waitgroup.go:77 +0x11d
github.com/coreos/flannel/backend/ipsec.NewCharonIKEDaemon(0x7f7ed82d4008, 0xc0003c2000, 0x100000000, 0xc000000000, 0x1ac604e, 0x23, 0x0, 0xc0000e80c8, 0x1b1fd78)
        /go/src/github.com/coreos/flannel/backend/ipsec/handle_charon.go:59 +0x2b9
github.com/coreos/flannel/backend/ipsec.(*IPSECBackend).RegisterNetwork(0xc0006843a0, 0x7f7ed82d4008, 0xc0003c2000, 0x100000000, 0xc000000000, 0xc0000e8000, 0x0, 0x18ce3d8, 0xc00062fd00, 0xc00062fd68)
        /go/src/github.com/coreos/flannel/backend/ipsec/ipsec.go:115 +0x3f1
main.main()
        /go/src/github.com/coreos/flannel/main.go:289 +0x853
```
You are able to reproduce this by updating go to a newer version (>=11) and running e2e-tests. Consider to patch #1198 and #1205 in your branch before.

The WaitGroup is used to ensure that the shutdown handler for the daemon is called once before terminating flannel.

https://github.com/coreos/flannel/blob/16b0fe66285d1ad1f42b154ab852682f6fafb1a7/backend/ipsec/handle_charon.go#L59-L69

There is a way to solve this issue by spawning the charon daemon before we try to acquire a subnet. This would even prevent us from having a not routable subnet registered when charon could not get spawned on a host. Spawning charon does not require any informations about the subnet.

This PR ensures that charon daemon spawns before acquiring a subnet and prepares flannel to upgrade go version.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
ensure charon daemon spawns before acquiring a subnet
```
