### PR TITLE
Use remote VNI for Windows

### DIFF
--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -88,8 +88,10 @@ func New(sm subnet.Manager, extIface *backend.ExternalInterface) (backend.Backen
 	return backend, nil
 }
 
-func newSubnetAttrs(publicIP net.IP, mac net.HardwareAddr) (*subnet.LeaseAttrs, error) {
-	data, err := json.Marshal(&vxlanLeaseAttrs{hardwareAddr(mac)})
+func newSubnetAttrs(publicIP net.IP, vnid uint16, mac net.HardwareAddr) (*subnet.LeaseAttrs, error) {
+	data, err := json.Marshal(&vxlanLeaseAttrs{
+		VNI:     vnid,
+		VtepMAC: hardwareAddr(mac)})
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +138,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg sync.WaitGroup, 
 	}
 	dev.directRouting = cfg.DirectRouting
 
-	subnetAttrs, err := newSubnetAttrs(be.extIface.ExtAddr, dev.MACAddr())
+	subnetAttrs, err := newSubnetAttrs(be.extIface.ExtAddr, uint16(cfg.VNI), dev.MACAddr())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/vxlan/vxlan_network.go
+++ b/backend/vxlan/vxlan_network.go
@@ -84,6 +84,7 @@ func (nw *network) MTU() int {
 }
 
 type vxlanLeaseAttrs struct {
+	VNI     uint16
 	VtepMAC hardwareAddr
 }
 

--- a/backend/vxlan/vxlan_network_windows.go
+++ b/backend/vxlan/vxlan_network_windows.go
@@ -101,6 +101,11 @@ func (nw *network) handleSubnetEvents(batch []subnet.Event) {
 			continue
 		}
 
+		if vxlanAttrs.VNI < 4096 {
+			log.Error("VNI is required to greater than or equal to 4096 on Windows.")
+			continue
+		}
+
 		hnsnetwork, err := hcn.GetNetworkByName(nw.dev.link.Name)
 		if err != nil {
 			log.Errorf("Unable to find network %v, error: %v", nw.dev.link.Name, err)
@@ -109,7 +114,7 @@ func (nw *network) handleSubnetEvents(batch []subnet.Event) {
 		managementIp := event.Lease.Attrs.PublicIP.String()
 
 		networkPolicySettings := hcn.RemoteSubnetRoutePolicySetting{
-			IsolationId:                 4096,
+			IsolationId:                 vxlanAttrs.VNI,
 			DistributedRouterMacAddress: net.HardwareAddr(vxlanAttrs.VtepMAC).String(),
 			ProviderAddress:             managementIp,
 			DestinationPrefix:           event.Lease.Subnet.String(),


### PR DESCRIPTION
Windows currently doesn't support any other VNI that 4096. The VNI for the remote should be retrieved from the subnet lease and set in the Policies of the vxlan HNS-Network. However, on Linu, flannel does not include the VNI in the Lease Attributes. 