### PR TITLE
update troubleshooting.md

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -66,6 +66,8 @@ When using `vxlan` backend, kernel uses UDP port 8472 for sending encapsulated p
 
 Make sure that your firewall rules allow this traffic for all hosts participating in the overlay network.
 
+Make sure that your firewall rules allow traffic from pod network cidr visit your kubernetes master node.
+
 # Kubernetes Specific
 The flannel kube subnet manager relies on the fact that each node already has a `podCIDR` defined.
 


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

## Description

It would be marked or coredns/kube-dns would parse following error and make kubernetes deploy failed:
```
E0117 06:47:03.256959       1 reflector.go:134] github.com/coredns/coredns/plugin/kubernetes/controller.go:317: Failed to list *v1.Endpoints: Get https://10.96.0.1:443/api/v1/endpoints?limit=500&resourceVersion=0: dial tcp 10.96.0.1:443: connect: no route to host
E0117 06:47:03.256959       1 reflector.go:134] github.com/coredns/coredns/plugin/kubernetes/controller.go:317: Failed to list *v1.Endpoints: Get https://10.96.0.1:443/api/v1/endpoints?limit=500&resourceVersion=0: dial tcp 10.96.0.1:443: connect: no route to host
```

The root cause is below rule:
```
-A KUBE-SEP-RXKY42C4R72HRU6E -p tcp -m tcp -j DNAT --to-destination 192.168.10.1:6443
```

If firewall reject pod network cidr to visit master node, it would always fail.
