### PR TITLE
Spruce up for release 12.0

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -169,7 +169,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.11.0-amd64
+        image: quay.io/coreos/flannel:v0.12.0-amd64
         command:
         - cp
         args:
@@ -183,7 +183,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.11.0-amd64
+        image: quay.io/coreos/flannel:v0.12.0-amd64
         command:
         - /opt/bin/flanneld
         args:
@@ -263,7 +263,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.11.0-arm64
+        image: quay.io/coreos/flannel:v0.12.0-arm64
         command:
         - cp
         args:
@@ -277,7 +277,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.11.0-arm64
+        image: quay.io/coreos/flannel:v0.12.0-arm64
         command:
         - /opt/bin/flanneld
         args:
@@ -357,7 +357,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.11.0-arm
+        image: quay.io/coreos/flannel:v0.12.0-arm
         command:
         - cp
         args:
@@ -371,7 +371,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.11.0-arm
+        image: quay.io/coreos/flannel:v0.12.0-arm
         command:
         - /opt/bin/flanneld
         args:
@@ -451,7 +451,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.11.0-ppc64le
+        image: quay.io/coreos/flannel:v0.12.0-ppc64le
         command:
         - cp
         args:
@@ -465,7 +465,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.11.0-ppc64le
+        image: quay.io/coreos/flannel:v0.12.0-ppc64le
         command:
         - /opt/bin/flanneld
         args:
@@ -545,7 +545,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.11.0-s390x
+        image: quay.io/coreos/flannel:v0.12.0-s390x
         command:
         - cp
         args:
@@ -559,7 +559,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.11.0-s390x
+        image: quay.io/coreos/flannel:v0.12.0-s390x
         command:
         - /opt/bin/flanneld
         args:

--- a/dist/functional-test.sh
+++ b/dist/functional-test.sh
@@ -25,7 +25,7 @@ setup_suite() {
 
     # Start etcd
     docker rm -f flannel-e2e-test-etcd >/dev/null 2>/dev/null
-    docker run --name=flannel-e2e-test-etcd -d -p 2379:2379 $ETCD_IMG $ETCD_LOCATION --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls $etcd_endpt >/dev/null
+    docker run --name=flannel-e2e-test-etcd -d --dns 8.8.8.8 -p 2379:2379 $ETCD_IMG $ETCD_LOCATION --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls $etcd_endpt >/dev/null
 }
 
 teardown_suite() {

--- a/subnet/etcdv2/mock_etcd.go
+++ b/subnet/etcdv2/mock_etcd.go
@@ -239,7 +239,7 @@ func (me *mockEtcd) set(ctx context.Context, key, value string, opts *etcd.SetOp
 
 	if node != nil {
 		if opts.PrevIndex > 0 && opts.PrevIndex < node.ModifiedIndex {
-			return nil, me.newError(etcd.ErrorCodeTestFailed, "Key %s PrevIndex %s less than node ModifiedIndex %d", key, opts.PrevIndex, node.ModifiedIndex)
+			return nil, me.newError(etcd.ErrorCodeTestFailed, "Key %s PrevIndex %v less than node ModifiedIndex %d", key, opts.PrevIndex, node.ModifiedIndex)
 		}
 
 		if opts.Dir != node.Dir {
@@ -342,7 +342,7 @@ func (me *mockEtcd) Delete(ctx context.Context, key string, opts *etcd.DeleteOpt
 	}
 
 	if opts.PrevIndex > 0 && opts.PrevIndex < node.ModifiedIndex {
-		return nil, me.newError(etcd.ErrorCodeTestFailed, "Key %s PrevIndex %s less than node ModifiedIndex %d", key, opts.PrevIndex, node.ModifiedIndex)
+		return nil, me.newError(etcd.ErrorCodeTestFailed, "Key %s PrevIndex %v less than node ModifiedIndex %d", key, opts.PrevIndex, node.ModifiedIndex)
 	}
 
 	if opts.PrevValue != "" && opts.PrevValue != node.Value {


### PR DESCRIPTION
## Description

- Clean up the test harness to run latest kube versions (both pre 1.16 and post 1.16)
- Changes to etcd tests to be compatible with hosts that have DNS search domains
- Modify the Documentation/kube-flannel.yml so that latest release images are matched

## Release Note

```release-note
None required
```