### PR TITLE
doc(awsvpc): correct the required permissions

### DIFF
--- a/Documentation/backends.md
+++ b/Documentation/backends.md
@@ -72,7 +72,7 @@ Recommended when running within an Amazon VPC, AWS VPC creates IP routes in an [
 
 Requirements:
 * Running on an EC2 instance that is in an Amazon VPC.
-* Permissions required: `CreateRoute`, `DeleteRoute`,`DescribeRouteTables`, `ModifyInstanceAttribute`, `DescribeInstances` (optional)
+* Permissions required: `CreateRoute`, `DeleteRoute`,`DescribeRouteTables`, `ModifyNetworkInterfaceAttribute`, `DescribeInstances` (optional)
 
 Type and options:
 * `Type` (string): `aws-vpc`

--- a/backend/awsvpc/awsvpc.go
+++ b/backend/awsvpc/awsvpc.go
@@ -56,7 +56,7 @@ type backendConfig struct {
 
 func (conf *backendConfig) routeTables() ([]string, error) {
 	if table, ok := conf.RouteTableID.(string); ok {
-		log.Info("RouteTableID configured as string: %s", table)
+		log.Infof("RouteTableID configured as string: %s", table)
 		return []string{table}, nil
 	}
 	if rawTables, ok := conf.RouteTableID.([]interface{}); ok {


### PR DESCRIPTION
## Description
The awsvpc backend requires permission `ModifyNetworkInterfaceAttribute` instead of `ModifyInstanceAttribute`, otherwise flanneld would complain 

```
failed to disable SourceDestCheck on eni-xxx: UnauthorizedOperation: You are not authorized to perform this operation.
```

In addtion, a small typo in `awsvpc.go` is fixed.


## Release Note

```release-note
None required
```
