### PR TITLE
Bugfix: VtepMac would be empty when lease re-acquire for windows without kubeSubnetMgr

### DIFF
--- a/backend/vxlan/vxlan_windows.go
+++ b/backend/vxlan/vxlan_windows.go
@@ -191,7 +191,10 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg sync.WaitGroup, 
 	}
 
 	lease, err = be.subnetMgr.AcquireLease(ctx, subnetAttrs)
-
+	if err != nil {
+		return nil, err
+	}
+	network.SubnetLease = lease
 	return network, nil
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

ISSUE: https://github.com/coreos/flannel/issues/1280

When we deploy flannel `vxlan` on windows and do not use `kubeSubnetMgr`.  We found vtepMac would be reset to "". 

See https://github.com/coreos/flannel/blob/master/backend/vxlan/vxlan_windows.go#L134
VtepMac is nil

See https://github.com/coreos/flannel/blob/master/backend/vxlan/vxlan_windows.go#L139
Acquire lease

See https://github.com/coreos/flannel/blob/master/backend/vxlan/vxlan_windows.go#L161
Create Network

Although https://github.com/coreos/flannel/blob/master/backend/vxlan/vxlan_windows.go#L188, re-acquire the lease. but we have not reset it to the `network` and it returned(mac is nil).

Then, `MonitorLease` would renew lease periodically use the network(mac is nil)
```
	// Kube subnet mgr doesn't lease the subnet for this node - it just uses the podCidr that's already assigned.
	if !opts.kubeSubnetMgr {
		err = MonitorLease(ctx, sm, bn, &wg)
		if err == errInterrupted {
			// The lease was "revoked" - shut everything down
			cancel()
		}
	}
```

See


## Todos
- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Bugfix: VtepMac would be empty when lease re-acquire for windows without kubeSubnetMgr
```
