### PR TITLE
fix CVE-2019-14697

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.11
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine
+FROM arm32v6/alpine:3.12
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine
+FROM arm64v8/alpine:3.12
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/alpine
+FROM ppc64le/alpine:3.12
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,4 +1,4 @@
-FROM s390x/alpine
+FROM s390x/alpine:3.12
 
 LABEL maintainer="Tom Denham <tom@tigera.io>"
 

--- a/images/iperf3/Makefile
+++ b/images/iperf3/Makefile
@@ -5,13 +5,13 @@ ARCH ?= amd64
 TEMP_DIR := $(shell mktemp -d)
 
 ifeq ($(ARCH),amd64)
-        BASEIMAGE=alpine:3.6
+        BASEIMAGE=alpine:3.12
 endif
 ifeq ($(ARCH),arm64)
-	BASEIMAGE=aarch64/alpine:3.6
+	BASEIMAGE=aarch64/alpine:3.12
 endif
 ifeq ($(ARCH),ppc64le)
-	BASEIMAGE=ppc64le/alpine:3.6
+	BASEIMAGE=ppc64le/alpine:3.12
 endif
 
 all: container


### PR DESCRIPTION
## Description
warn report by quay.io :
https://quay.io/repository/coreos/flannel/manifest/sha256:6d451d92c921f14bfb38196aacb6e506d4593c5b3c9d40a8b8a2506010dc3e10?tab=vulnerabilities

this security issue is not present in 3.11 :
https://github.com/alpinelinux/docker-alpine/issues/34


## Release Note
fix CVE-2019-14697

```release-note
use a recent alpine version with secure musl lib (CVE-2019-14697)
```
