### PR TITLE
Return context.Cacnceled in kube.WatchLeases

### DIFF
--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -298,7 +298,7 @@ func (ksm *kubeSubnetManager) WatchLeases(ctx context.Context, cursor interface{
 			Events: []subnet.Event{event},
 		}, nil
 	case <-ctx.Done():
-		return subnet.LeaseWatchResult{}, nil
+		return subnet.LeaseWatchResult{}, context.Canceled
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Currently when we use kubernetes subnet manager with
VXLAN backend, and flannel got tried to be gracefully
stopped by sending SIGTERM, flannel would stuck and sometimes
tried to delete arp, fdb, fib because `WatchLeases` would not return
context.Canceled which trigger cancel logic and insted just return
empty lease object which trigger reset functionality generate
deletedEvent for all of leases.

That's why to fix that, we need to return context.Cacnceled
for more details, please check following issue page
- https://github.com/coreos/flannel/issues/1308


## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
