### PR TITLE
Set priorityClassName to system-node-critical

### DIFF
--- a/Documentation/kube-flannel-aliyun.yml
+++ b/Documentation/kube-flannel-aliyun.yml
@@ -87,6 +87,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
+      priorityClassName: system-node-critical
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -151,6 +151,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
+      priorityClassName: system-node-critical
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -234,6 +235,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: arm64
+      priorityClassName: system-node-critical
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -317,6 +319,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: arm
+      priorityClassName: system-node-critical
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -400,6 +403,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: ppc64le
+      priorityClassName: system-node-critical
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -483,6 +487,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: s390x
+      priorityClassName: system-node-critical
       tolerations:
       - operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
## Description
This PR sets a `priorityClassName` to `system-node-critical` . The goal is to ensure that Flannel pods has higher precedence over other non-system pods in case the cluster run out of resources and pods needs to rescheduled onto the same worker.

## Release Note
```release-note
None required
```
