### PR TITLE
Run gofmt -w on backend/vxlan/device.go to pass CI

### DIFF
--- a/backend/vxlan/device.go
+++ b/backend/vxlan/device.go
@@ -25,8 +25,8 @@ import (
 	log "github.com/golang/glog"
 	"github.com/vishvananda/netlink"
 
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
 	"github.com/coreos/flannel/pkg/ip"
-        "github.com/containernetworking/plugins/pkg/utils/sysctl"
 )
 
 type vxlanDeviceAttrs struct {
@@ -62,7 +62,7 @@ func newVXLANDevice(devAttrs *vxlanDeviceAttrs) (*vxlanDevice, error) {
 		return nil, err
 	}
 
-        _, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", devAttrs.name), "0")
+	_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", devAttrs.name), "0")
 
 	return &vxlanDevice{
 		link: link,


### PR DESCRIPTION

## Description
CI Fix

https://github.com/coreos/flannel/commit/8abf12ad0c4ed0853ea6585d99e741cd4b81727b was merged but does not pass the `gofmt` test in CI

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
