### PR TITLE
add crash when failure in list or watch of kubernetes api server

### DIFF
--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -142,10 +142,18 @@ func newKubeSubnetManager(c clientset.Interface, sc *subnet.Config, nodeName, pr
 	indexer, controller := cache.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return ksm.client.CoreV1().Nodes().List(options)
+				obj, err := ksm.client.CoreV1().Nodes().List(options)
+				if err != nil {
+					glog.Exit(err, "failed to list nodes in newKubeSubnetManager")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return ksm.client.CoreV1().Nodes().Watch(options)
+				iface, err := ksm.client.CoreV1().Nodes().Watch(options)
+				if err != nil {
+					glog.Exit(err, "failed to watch nodes in newKubeSubnetManager")
+				}
+				return iface, err
 			},
 		},
 		&v1.Node{},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Address "Flanneld doesn't reconnect to the apiserver" - https://github.com/coreos/flannel/issues/1272

Add crash when failure in list or watch when talking to kubernetes api server. This should result in a retry loop for the connection (due to flannel being restarted).

Ideally the retry loop should be fully encapsulated inside flannel, however I didn't have much time to fix this problem. And it has been a month and no one has offered a better solution. I hope that this PR sparks that.

## Todos
~~- [ ] Tests~~
~~- [ ] Documentation~~
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Workaround for not reconnecting to api-server in windows
```
