### PR TITLE
Add --no-sanity-check to iptables-wrapper-installer.sh 

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -10,7 +10,7 @@ RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.or
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 COPY dist/iptables-wrapper-installer.sh /
-RUN /iptables-wrapper-installer.sh
+RUN /iptables-wrapper-installer.sh --no-sanity-check
 
 ENTRYPOINT ["/opt/bin/flanneld"]
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -10,7 +10,7 @@ RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.or
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 COPY dist/iptables-wrapper-installer.sh /
-RUN /iptables-wrapper-installer.sh
+RUN /iptables-wrapper-installer.sh --no-sanity-check
 
 ENTRYPOINT ["/opt/bin/flanneld"]
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -10,7 +10,7 @@ RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.or
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 COPY dist/iptables-wrapper-installer.sh /
-RUN /iptables-wrapper-installer.sh
+RUN /iptables-wrapper-installer.sh --no-sanity-check
 
 ENTRYPOINT ["/opt/bin/flanneld"]
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -10,7 +10,7 @@ RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.or
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 COPY dist/iptables-wrapper-installer.sh /
-RUN /iptables-wrapper-installer.sh
+RUN /iptables-wrapper-installer.sh --no-sanity-check
 
 ENTRYPOINT ["/opt/bin/flanneld"]
 


### PR DESCRIPTION
## Description
Add --no-sanity-check to iptables-wrapper-installer.sh for architectures other than amd64

This is required as when performing QemuUserEmulation, it is not possible to actually execute the `iptables-nft` to determine the version. We are still executing the sanity check on `amd64` as that is a native architecture for the build pipeline.

The correct links are still created and the end `iptables-wrapper` is correct, i.e.:
```
root@jobsite:~/go/src/github.com/coreos/flannel# git tag v0.13.0-rc1
root@jobsite:~/go/src/github.com/coreos/flannel# make release
#### SNIP ####
root@jobsite:~/go/src/github.com/coreos/flannel# docker run --rm -it --entrypoint /bin/sh quay.io/coreos/flannel:v0.13.0-rc1-arm
/ # ls -l /sbin | grep iptables-wrapper
lrwxrwxrwx    1 root     root            22 Aug 20 16:19 ip6tables -> /sbin/iptables-wrapper
lrwxrwxrwx    1 root     root            22 Aug 20 16:19 ip6tables-restore -> /sbin/iptables-wrapper
lrwxrwxrwx    1 root     root            22 Aug 20 16:19 ip6tables-save -> /sbin/iptables-wrapper
lrwxrwxrwx    1 root     root            22 Aug 20 16:19 iptables -> /sbin/iptables-wrapper
lrwxrwxrwx    1 root     root            22 Aug 20 16:19 iptables-restore -> /sbin/iptables-wrapper
lrwxrwxrwx    1 root     root            22 Aug 20 16:19 iptables-save -> /sbin/iptables-wrapper
-rwxr-xr-x    1 root     root          1797 Aug 20 16:19 iptables-wrapper
/ # cat /sbin/iptables-wrapper
#### SNIP ####
# Update links to point to the selected binaries
for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
    rm -f "/sbin/${cmd}"
    ln -s "/sbin/xtables-${mode}-multi" "/sbin/${cmd}"
done 2>/dev/null || failed=1
if [ "${failed:-0}" = 1 ]; then
    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
    # fake it, though this will probably also fail if they aren't root
    exec "/sbin/xtables-${mode}-multi" "$0" "$@"
fi
#### SNIP ####
```

## Release Note
```release-note
None required
```
