### PR TITLE
Modify kube-flannel.yaml to use rbac.authorization.k8s.io/v1

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -47,7 +47,7 @@ spec:
     rule: 'RunAsAny'
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 rules:
@@ -76,7 +76,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 roleRef:

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -22,6 +22,8 @@ When you run pods, they will be allocated IP addresses from the pod network CIDR
 
 `kube-flannel.yaml` has some features that aren't compatible with older versions of Kubernetes, though flanneld itself should work with any version of Kubernetes.
 
+### For Kubernetes v1.6~v1.15
+
 If you see errors saying `found invalid field...` when you try to apply `kube-flannel.yaml` then you can try the "legacy" manifest file
 * `kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel-legacy.yml`
 
@@ -30,6 +32,10 @@ This file does not bundle RBAC permissions. If you need those, run
 
 If you didn't apply the `kube-flannel-rbac.yml` manifest and you need to, you'll see errors in your flanneld logs about failing to connect.
 * `Failed to create SubnetManager: error retrieving pod spec...`
+
+### For Kubernetes v1.16
+
+`kube-flannel.yaml` uses `ClusterRole` & `ClusterRoleBinding` of `rbac.authorization.k8s.io/v1`. When you use Kubernetes v1.16, you should replace `rbac.authorization.k8s.io/v1` to `rbac.authorization.k8s.io/v1beta1` because `rbac.authorization.k8s.io/v1` had become GA from Kubernetes v1.17.
 
 ## The flannel CNI plugin
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Though not required, it's recommended that flannel uses the Kubernetes API as it
 
 Flannel can be added to any existing Kubernetes cluster though it's simplest to add `flannel` before any pods using the pod network have been started.
 
-For Kubernetes v1.7+
+For Kubernetes v1.17+
 `kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml`
 
 See [Kubernetes](Documentation/kubernetes.md) for more details.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
**[Type of fix] :** Bug

This commit modifies `Document/kube-flannel.yaml` to use `ClusterRole` & `ClusterRoleBinding` of `rbac.authorization.k8s.io/v1`.

Before this commit, `rbac.authorization.k8s.io/v1beta1` is used at `kube-flannel.yaml`. However, from Kubernetes v1.17, this v1beta1 version is [deprecated](https://v1-17.docs.kubernetes.io/docs/setup/release/notes/#deprecations-and-removals) and `rbac.authorization.k8s.io/v1` becomes GA.

At the time of writing this commit, latest Kubernets version is v1.19. So, according to Kubernetes support policy, only v1.19, v1.18 & v1.17 are supported and it's safe to use `rbac.authorization.k8s.io/v1` now.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
