### PR TITLE
subnets: move forward the cursor to skip illegal subnet

### DIFF
--- a/subnet/etcdv2/local_manager.go
+++ b/subnet/etcdv2/local_manager.go
@@ -345,6 +345,9 @@ func (m *LocalManager) WatchLeases(ctx context.Context, cursor interface{}) (Lea
 		log.Warning("Watch of subnet leases failed because etcd index outside history window")
 		return m.leasesWatchReset(ctx)
 
+	case index != 0:
+		return LeaseWatchResult{Cursor: watchCursor{index}}, err
+
 	default:
 		return LeaseWatchResult{}, err
 	}

--- a/subnet/watch.go
+++ b/subnet/watch.go
@@ -40,6 +40,10 @@ func WatchLeases(ctx context.Context, sm Manager, ownLease *Lease, receiver chan
 				return
 			}
 
+			if res.Cursor != nil {
+				cursor = res.Cursor
+			}
+
 			log.Errorf("Watch subnets: %v", err)
 			time.Sleep(time.Second)
 			continue


### PR DESCRIPTION
This PR fixs an issue when flannel gets illegal subnet event in
watching leases, it doesn't move forward the etcd cursor and
will stuck in the same invalid event forever.

## Description
As the commit message mentions, in local_manager mode when the "WatchLeases" goroutine gets an invalid subnet event (in detail [function parseSubnetWatchResponse](https://github.com/coreos/flannel/blob/be2cb996dab08c68614a05e3bf30020c0a9fbafc/subnet/etcdv2/registry.go#L228) returns error), it doesn't move the cursor forward to skip this invalid subnet as the error string says.

This PR try to fix the issue.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
subnets: move forward the cursor to skip illegal subnet
```
