### PR TITLE
ipsec: use well known paths of charon daemon

### DIFF
--- a/backend/ipsec/ipsec.go
+++ b/backend/ipsec/ipsec.go
@@ -32,9 +32,9 @@ import (
 	Flannel's approach to IPSec uses Strongswan to handle the key exchange (using IKEv2) and the kernel to handle the
 	actual encryption.
 
-	Strongswan's "charon" is bundled in the flannel container. Flannel runs it as a child process when the ipsec backend
-	is selected and communicates with it using the "VICI" interface. Strongswan ships a utility "swanctl" which also
-	uses the VICI interface. This utility is bundled in the flannel container and can help with debugging.
+	Flannel runs Strongswan's "charon" as a child process when the ipsec backend is selected and communicates with it
+	using the "VICI" interface. Strongswan ships a utility "swanctl" which also uses the VICI interface. This utility
+	is bundled in the flannel container and can help with debugging.
 
 	The file "handle_charon.go" contains the logic for working with the charon. It supports creating a "CharonIKEDaemon"
 	which supports loading the PSK into the charon and adding and removing connections.


### PR DESCRIPTION
## Description
Charon ike daemon path is hardcoded according to its install location
in alpine distribution off which is based the flannel image used in
standard kubernetes deployment.

This commit hardcodes other well known paths of charon daemon in
different distributions to improve support in manual execution
scenarios or customized flannel images.

```release-note
None required
```
