### PR TITLE
move tag to 13.1-rc2

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -166,7 +166,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.13.1-rc1
+        image: quay.io/coreos/flannel:v0.13.1-rc2
         command:
         - cp
         args:
@@ -180,7 +180,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.13.1-rc1
+        image: quay.io/coreos/flannel:v0.13.1-rc2
         command:
         - /opt/bin/flanneld
         args:


### PR DESCRIPTION
## Description
For release candidate v13.1-rc2

## Release Note

```release-note
60464442 Update vendor with glog to klog change
31dbe1c5 Move from glog to klog
a85e1279 fix(host-gw): failed to restart if gateway hnsep existed
e5a30dae ipsec: use well known paths of charon daemon
e951cf74 client-go version bump
```
