### PR TITLE
install flannel cni plugin binary

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -177,7 +177,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.14.0
+        image: quay.io/coreos/flannel:v0.15.0-rc1
         command:
         - cp
         args:
@@ -191,7 +191,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.14.0
+        image: quay.io/coreos/flannel:v0.15.0-rc1
         command:
         - /opt/bin/flanneld
         args:


### PR DESCRIPTION
using an init container
and the release images from flannel-io/cni-plugin repo.

## Description

All new releases will now rely on the cni-plugin built through the flannel-io/cni-plugin repo.
All prior releases used to rely on kubeadm supplied binary.

## Todos

## Release Note
- kubeadm does not supply cni plugin for flannel anymore, so kube-flannel.yml will create it on host system using an init container


