### PR TITLE
vxlan: Generate MAC address before creating a link

### DIFF
--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -1,0 +1,35 @@
+// Copyright 2021 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mac
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+)
+
+// NewHardwareAddr generates a new random hardware (MAC) address, local and
+// unicast.
+func NewHardwareAddr() (net.HardwareAddr, error) {
+	hardwareAddr := make(net.HardwareAddr, 6)
+	if _, err := rand.Read(hardwareAddr); err != nil {
+		return nil, fmt.Errorf("could not generate random MAC address: %w", err)
+	}
+
+	// Ensure that address is locally administered and unicast.
+	hardwareAddr[0] = (hardwareAddr[0] & 0xfe) | 0x02
+
+	return hardwareAddr, nil
+}

--- a/pkg/mac/mac_test.go
+++ b/pkg/mac/mac_test.go
@@ -1,0 +1,28 @@
+// Copyright 2021 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mac
+
+import (
+	"testing"
+)
+
+func TestNewHardwareAddr(t *testing.T) {
+	// Ignore the actual address, since it's random.
+	// But an error should never be returned.
+	_, err := NewHardwareAddr()
+	if err != nil {
+		t.Fatalf(err)
+	}
+}


### PR DESCRIPTION
systemd 242+ assigns MAC addresses for all virtual devices which don't
have the address assigned already. That resulted in systemd overriding
MAC addresses of flannel.* interfaces. The fix which prevents systemd
from setting the address is to define the concrete MAC address when
creating the link.

Fixes: #1155
Ref: k3s-io/k3s#4188
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Tests
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix the race condition with systemd 242+ by generating MAC address before creating a link
```
