### PR TITLE
Update api version for rbac.authorization.k8s.io

### DIFF
--- a/Documentation/k8s-manifests/kube-flannel-rbac.yml
+++ b/Documentation/k8s-manifests/kube-flannel-rbac.yml
@@ -4,7 +4,7 @@
 # $ kubectl create --namespace kube-system -f kube-flannel-legacy.yml
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 rules:
@@ -29,7 +29,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 roleRef:


### PR DESCRIPTION
## Description
Modify Documentation/k8s-manifests/kube-flannel-rbac.yml to use ClusterRole & ClusterRoleBinding of 'rbac.authorization.k8s.io/v1'.

v1beta1 is deprecated as of kubernetes v1.17, this v1beta1


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
