### PR TITLE
Fix wrong interface match when using the "iface-regex" option

### DIFF
--- a/main.go
+++ b/main.go
@@ -572,6 +572,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int) (*backend.Exter
 			return nil, fmt.Errorf("error listing all interfaces: %s", err)
 		}
 
+	ifaceLoop:
 		// Check IP
 		for _, ifaceToMatch := range ifaces {
 			switch ipStack {
@@ -585,7 +586,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int) (*backend.Exter
 				if ifregex.MatchString(ifaceIP.String()) {
 					ifaceAddr = ifaceIP
 					iface = &ifaceToMatch
-					break
+					break ifaceLoop
 				}
 			case ipv6Stack:
 				ifaceIP, err := ip.GetInterfaceIP6Addr(&ifaceToMatch)
@@ -597,7 +598,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int) (*backend.Exter
 				if ifregex.MatchString(ifaceIP.String()) {
 					ifaceV6Addr = ifaceIP
 					iface = &ifaceToMatch
-					break
+					break ifaceLoop
 				}
 			case dualStack:
 				ifaceIP, err := ip.GetInterfaceIP4Addr(&ifaceToMatch)
@@ -616,7 +617,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int) (*backend.Exter
 					ifaceAddr = ifaceIP
 					ifaceV6Addr = ifaceV6IP
 					iface = &ifaceToMatch
-					break
+					break ifaceLoop
 				}
 			}
 		}


### PR DESCRIPTION
## Description

We've noticed that when using the `iface-regex` CLI option, the wrong interface would get selected even though it was the only interface matching the IP specified in the regex pattern.

Upon closer inspection of the code, it looks like attempting to break away from the main `for` loop only exits the `switch` statement. 

This makes it so when there is a regex match, as we continue iterating through all the available network interfaces, the last element will always get stored since `ifaceToMatch` is passed by reference.

## Scenario

### Interface list
```
3: enp3s0f1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether d0:50:99:fe:29:21 brd ff:ff:ff:ff:ff:ff
    inet 172.16.15.2/16 brd 172.16.255.255 scope global enp3s0f1
       valid_lft forever preferred_lft forever

...

166872: vethf134d2d5@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master cni0 state UP group default
    link/ether 82:82:b4:8d:b5:bc brd ff:ff:ff:ff:ff:ff link-netns cni-206b7340-a74b-2ae2-999d-6f4ecc4a3398
    inet6 fe80::8082:b4ff:fe8d:b5bc/64 scope link
       valid_lft forever preferred_lft forever
```

### Launch options used
```sh
./flanneld --ip-masq --kube-subnet-mgr --iface-regex=^172\\.16\\.
```

### Expected result
```sh
I0207 09:15:43.273911       1 main.go:698] Using interface with name enp3s0f1 and address 172.16.15.2
I0207 09:15:43.273930       1 main.go:720] Defaulting external address to interface address (172.16.15.2)
```

### Actual result
```sh
I0207 09:15:43.273911       1 main.go:698] Using interface with name vethf134d2d5 and address 172.16.15.2
I0207 09:15:43.273930       1 main.go:720] Defaulting external address to interface address (172.16.15.2)
```

<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
