### PR TITLE
capture close() err on subnet file save

### DIFF
--- a/pkg/subnet/subnet.go
+++ b/pkg/subnet/subnet.go
@@ -15,6 +15,7 @@
 package subnet
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -74,31 +75,26 @@ func WriteSubnetFile(path string, config *Config, ipMasq bool, sn ip.IP4Net, ipv
 		return err
 	}
 	tempFile := filepath.Join(dir, "."+name)
-	f, err := os.Create(tempFile)
-	if err != nil {
-		return err
-	}
+	var b bytes.Buffer
 	if config.EnableIPv4 {
-		fmt.Fprintf(f, "FLANNEL_NETWORK=%s\n", config.Network)
+		fmt.Fprintf(&b, "FLANNEL_NETWORK=%s\n", config.Network)
 		// Write out the first usable IP by incrementing sn.IP by one
 		sn.IncrementIP()
 
-		fmt.Fprintf(f, "FLANNEL_SUBNET=%s\n", sn)
+		fmt.Fprintf(&b, "FLANNEL_SUBNET=%s\n", sn)
 	}
 	if config.EnableIPv6 {
-		fmt.Fprintf(f, "FLANNEL_IPV6_NETWORK=%s\n", config.IPv6Network)
+		fmt.Fprintf(&b, "FLANNEL_IPV6_NETWORK=%s\n", config.IPv6Network)
 		// Write out the first usable IP by incrementing ip6Sn.IP by one
 		ipv6sn.IncrementIP()
-		fmt.Fprintf(f, "FLANNEL_IPV6_SUBNET=%s\n", ipv6sn)
+		fmt.Fprintf(&b, "FLANNEL_IPV6_SUBNET=%s\n", ipv6sn)
 	}
 
-	fmt.Fprintf(f, "FLANNEL_MTU=%d\n", mtu)
-	_, err = fmt.Fprintf(f, "FLANNEL_IPMASQ=%v\n", ipMasq)
-	if err != nil {
+	fmt.Fprintf(&b, "FLANNEL_MTU=%d\n", mtu)
+	fmt.Fprintf(&b, "FLANNEL_IPMASQ=%v\n", ipMasq)
+
+	if err := os.WriteFile(tempFile, b.Bytes(), 0644); err != nil {
 		return err
-	}
-	if err := f.Close(); err != nil {
-		return er
 	}
 
 	// rename(2) the temporary file to the desired location so that it becomes


### PR DESCRIPTION
## Description

The OS may accept write()s but may fail on close(), which is currently ignored.
Because it's ignored, it won't be logged anywhere either. (I'm sending this PR because I'm seeing missing subnet.env file on disk, but there's no `Failed to write subnet file`).

## Todos
- [ ] Tests: N/A
- [ ] Documentation: N/A
- [ ] Release note: N/A

## Release Note


```release-note
None required
```
