### PR TITLE
Fix: recreate VXLAN device (flannel.*) when external interface is deleted and re-added

### DIFF
--- a/main.go
+++ b/main.go
@@ -301,6 +301,7 @@ func main() {
 		PublicIPv6: opts.publicIPv6,
 	}
 	// Check the default interface only if no interfaces are specified
+
 	if len(opts.iface) == 0 && len(opts.ifaceRegex) == 0 && len(opts.ifaceCanReach) == 0 {
 		if len(opts.publicIP) > 0 {
 			extIface, err = ipmatch.LookupExtIface(opts.publicIP, "", "", ipStack, optsPublicIP)
@@ -431,8 +432,8 @@ func main() {
 				for {
 					select {
 					case <-ctx.Done():
-					     break
-				     	case <-time.After(time.Duration(opts.iptablesResyncSeconds) * time.Second):
+						break
+					case <-time.After(time.Duration(opts.iptablesResyncSeconds) * time.Second):
 						if err := ip.AddBlackholeV4Route(bn.Lease().Subnet.ToIPNet()); err != nil {
 							log.Errorf("Failed to setup blackhole route, %v", err)
 						}
@@ -445,8 +446,8 @@ func main() {
 				for {
 					select {
 					case <-ctx.Done():
-					     break
-				     	case <-time.After(time.Duration(opts.iptablesResyncSeconds) * time.Second):
+						break
+					case <-time.After(time.Duration(opts.iptablesResyncSeconds) * time.Second):
 						if err := ip.AddBlackholeV6Route(bn.Lease().IPv6Subnet.ToIPNet()); err != nil {
 							log.Errorf("Failed to setup blackhole route, %v", err)
 						}

--- a/pkg/backend/common.go
+++ b/pkg/backend/common.go
@@ -25,6 +25,7 @@ import (
 
 type ExternalInterface struct {
 	Iface       *net.Interface
+	IfaceName   string
 	IfaceAddr   net.IP
 	IfaceV6Addr net.IP
 	ExtAddr     net.IP

--- a/pkg/ipmatch/match.go
+++ b/pkg/ipmatch/match.go
@@ -302,6 +302,7 @@ func LookupExtIface(ifname string, ifregexS string, ifcanreach string, ipStack i
 
 	return &backend.ExternalInterface{
 		Iface:       iface,
+		IfaceName:   iface.Name,
 		IfaceAddr:   ifaceAddr,
 		IfaceV6Addr: ifaceV6Addr,
 		ExtAddr:     extAddr,


### PR DESCRIPTION
## Description

This PR fixes a bug in the VXLAN backend where the `flannel.<vni>` interface was not reliably re-created when the external network interface was deleted and re-added. 

### Changes in this PR
- This is a bug fix PR for issue #2247
- This PR adds a watcher to monitor for missing VXLAN devices and trigger automatic re-creation once the external interface is available again.
- Manual testing:
	1. Deploy a cluster with Flannel VXLAN backend.
	2. Verify VXLAN interface `flannel.<vni>` exists and pods can communicate.
	3. Delete and recreate the external interface (or toggle it down/up).
	4. Check Flannel logs for VXLAN device recreation, also with the a'p a command
	5. Deploy two test pods and verify that pod-to-pod ping works.

- Affected component: VXLAN backend (network and device setup).

## Todos

* [ ] Tests
* [ ] Documentation
* [ ] Release note

## Release Not"
```release-note
Added watcher to detect missing VXLAN devices and automatically recreate them when the external interface reappears.
```
