### PR TITLE
Fix interface IP address lookup in dual-stack mode

### DIFF
--- a/pkg/ipmatch/match.go
+++ b/pkg/ipmatch/match.go
@@ -247,17 +247,22 @@ func LookupExtIface(ifname string, ifregexS string, ifcanreach string, ipStack i
 			return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
 		}
 		ifaceV6Addr = ifaceV6Addrs[0]
-	} else if ipStack == dualStack && ifaceAddr == nil && ifaceV6Addr == nil {
-		ifaceAddrs, err = ip.GetInterfaceIP4Addrs(iface)
-		if err != nil || len(ifaceAddrs) == 0 {
-			return nil, fmt.Errorf("failed to find IPv4 address for interface %s", iface.Name)
+	} else if ipStack == dualStack {
+		if ifaceAddr == nil {
+			ifaceAddrs, err = ip.GetInterfaceIP4Addrs(iface)
+			if err != nil || len(ifaceAddrs) == 0 {
+				return nil, fmt.Errorf("failed to find IPv4 address for interface %s", iface.Name)
+			}
+			ifaceAddr = ifaceAddrs[0]
 		}
-		ifaceAddr = ifaceAddrs[0]
-		ifaceV6Addrs, err = ip.GetInterfaceIP6Addrs(iface)
-		if err != nil || len(ifaceV6Addrs) == 0 {
-			return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
+
+		if ifaceV6Addr == nil {
+			ifaceV6Addrs, err = ip.GetInterfaceIP6Addrs(iface)
+			if err != nil || len(ifaceV6Addrs) == 0 {
+				return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
+			}
+			ifaceV6Addr = ifaceV6Addrs[0]
 		}
-		ifaceV6Addr = ifaceV6Addrs[0]
 	}
 
 	if ifaceAddr != nil {

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -37,6 +37,7 @@ func TestLookupExtIface(t *testing.T) {
 	execOrFail("sudo", "ip", "addr", "add", "172.16.30.18", "dev", "dummy0")
 	execOrFail("sudo", "ip", "addr", "add", "172.16.31.200", "dev", "dummy0")
 	execOrFail("sudo", "ip", "addr", "add", "172.16.32.100", "dev", "dummy0")
+	execOrFail("sudo", "ip", "addr", "add", "2001:db8::1/64", "dev", "dummy0")
 	execOrFail("sudo", "ip", "link", "set", "dummy0", "up")
 	execOrFail("sudo", "ip", "route", "add", "172.16.32.254", "via", "172.16.32.100", "dev", "dummy0")
 
@@ -102,6 +103,24 @@ func TestLookupExtIface(t *testing.T) {
 		}
 		if backendInterface.IfaceAddr.String() != "172.16.30.18" {
 			t.Fatalf("iface addr not equal, expected=%v actual=%v", "172.16.30.18", backendInterface.IfaceAddr.String())
+		}
+	})
+
+	t.Run("ByIPv4DualStack", func(t *testing.T) {
+		backendInterface, err := LookupExtIface("172.16.30.18", "", "", dualStack, PublicIPOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != "dummy0" {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
+		}
+		if backendInterface.IfaceAddr.String() != "172.16.30.18" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "172.16.30.18", backendInterface.IfaceAddr.String())
+		}
+		if backendInterface.IfaceV6Addr.String() != "2001:db8::1/64" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "2001:db8::1/64", backendInterface.IfaceV6Addr.String())
 		}
 	})
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Previously, interface address lookup was performed only if both IPv4 and IPv6 addresses were not known, which is an impossible scenario when an interface is selected based on IP address. 

For example, `--iface 127.0.0.1` would result in `lo` interface selected with IPv4 known and set to `127.0.0.1`, but it'd never have triggered IPv6 address lookup because of the wrong prerequisite of having to have both IPv4 and IPv6 set to `nil`.

This change ensures that the address lookup occurs independently for each IP protocol.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
match: ensure IP addresses are looked up for each IP protocol when a corresponding value is not provided by `PublicIPv4` or `PublicIPv6` properties in dual-stack mode
```
