### PR TITLE
ip: improve primary address selection to account for address flags

### DIFF
--- a/pkg/ip/iface.go
+++ b/pkg/ip/iface.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"syscall"
 
 	"github.com/vishvananda/netlink"
@@ -54,29 +55,19 @@ func GetInterfaceIP4Addrs(iface *net.Interface) ([]net.IP, error) {
 		return nil, err
 	}
 
+	// sort addresses in preferred usage order
+	slices.SortFunc(addrs, compareAddrs)
+
+	// map rich ip information from netlink into the stdlib data structure
+	// while filtering addresses that aren't relevant or usable
 	ipAddrs := make([]net.IP, 0)
-
-	// prefer non link-local addr
-	ll := make([]net.IP, 0)
-
-	for _, addr := range addrs {
-		if addr.IP.To4() == nil {
-			continue
+	for _, i := range addrs {
+		// address must be IPv4, global unicast or link-local unicast and non-deprecated
+		if i.IP.To4() != nil &&
+			(i.IP.IsGlobalUnicast() || i.IP.IsLinkLocalUnicast()) &&
+			i.Flags&syscall.IFA_F_DEPRECATED == 0 {
+			ipAddrs = append(ipAddrs, i.IP)
 		}
-
-		if addr.IP.IsGlobalUnicast() {
-			ipAddrs = append(ipAddrs, addr.IP)
-			continue
-		}
-
-		if addr.IP.IsLinkLocalUnicast() {
-			ll = append(ll, addr.IP)
-		}
-	}
-
-	if len(ll) > 0 {
-		// didn't find global but found link-local. it'll do.
-		ipAddrs = append(ipAddrs, ll...)
 	}
 
 	if len(ipAddrs) > 0 {
@@ -92,29 +83,19 @@ func GetInterfaceIP6Addrs(iface *net.Interface) ([]net.IP, error) {
 		return nil, err
 	}
 
+	// sort addresses in preferred usage order
+	slices.SortFunc(addrs, compareAddrs)
+
+	// map rich ip information from netlink into the stdlib data structure
+	// while filtering addresses that aren't relevant or usable
 	ipAddrs := make([]net.IP, 0)
-
-	// prefer non link-local addr
-	ll := make([]net.IP, 0)
-
-	for _, addr := range addrs {
-		if addr.IP.To16() == nil {
-			continue
+	for _, i := range addrs {
+		// address must be IPv6, global unicast or link-local unicast and non-deprecated
+		if i.IP.To16() != nil &&
+			(i.IP.IsGlobalUnicast() || i.IP.IsLinkLocalUnicast()) &&
+			i.Flags&syscall.IFA_F_DEPRECATED == 0 {
+			ipAddrs = append(ipAddrs, i.IP)
 		}
-
-		if addr.IP.IsGlobalUnicast() {
-			ipAddrs = append(ipAddrs, addr.IP)
-			continue
-		}
-
-		if addr.IP.IsLinkLocalUnicast() {
-			ll = append(ll, addr.IP)
-		}
-	}
-
-	if len(ll) > 0 {
-		// didn't find global but found link-local. it'll do.
-		ipAddrs = append(ipAddrs, ll...)
 	}
 
 	if len(ipAddrs) > 0 {
@@ -347,4 +328,32 @@ func AddBlackholeV6Route(ipV6Dest *net.IPNet) error {
 		err = netlink.RouteAdd(&route)
 	}
 	return err
+}
+
+// compareAddrs compares two netlink address in terms of which one should be used preferably.
+// Addresses which are supposed to be completely disregarded are not considered specially and should be filtered separately
+func compareAddrs(a, b netlink.Addr) int {
+	// global unicast addresses are preferable to link-local addresses because they probably have better reachability
+	if a.IP.IsGlobalUnicast() && b.IP.IsLinkLocalUnicast() {
+		return -1
+	} else if a.IP.IsLinkLocalUnicast() && b.IP.IsGlobalUnicast() {
+		return 1
+	}
+
+	// manually assigned addresses are preferable to auto-assigned or generated addresses
+	if a.Flags&syscall.IFA_F_PERMANENT == syscall.IFA_F_PERMANENT && b.Flags&syscall.IFA_F_PERMANENT == 0 {
+		return -1
+	} else if a.Flags&syscall.IFA_F_PERMANENT == 0 && b.Flags&syscall.IFA_F_PERMANENT == syscall.IFA_F_PERMANENT {
+		return 1
+	}
+
+	// non-temporary address are preferable to temporary addresses
+	if a.Flags&syscall.IFA_F_TEMPORARY == 0 && b.Flags&syscall.IFA_F_TEMPORARY == syscall.IFA_F_TEMPORARY {
+		return -1
+	} else if a.Flags&syscall.IFA_F_TEMPORARY == syscall.IFA_F_TEMPORARY && b.Flags&syscall.IFA_F_TEMPORARY == 0 {
+		return 1
+	}
+
+	// anything else doesn't really matter
+	return 0
 }


### PR DESCRIPTION
## Description
This change uses known IFA_F flags that are attached to interface addresses by the linux kernel to differentiate between the usability of multiple addresses.
Primarily, this deprioritizes temporary and completely excludes deprecated addresses that have been assigned to a node through RFC7217 address generation techniques. It also explicitly prioritizes addresses that are marked as "manually assigned" by the kernel.

This improves routing stability for all backends that require an address to reach a node.
Closes #2293 but generally speaking in any case where a node has multiple addresses to choose from, flannel should consciously choose the most useful and less likely to suddenly change.

## Performed Testing

I have already patches this change into my own three-node linux k3s setup and have run manual end-to-end tests there. The change has the intended outcome in that temporary addresses are no longer chosen as primary addresses.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

I do think a release note is required since this changes the way flannel chooses primary addresses which has potential impact in user deployments.
There should be no action required by a user during updates but they should be aware that after restarting flannel, the primary address chosen by it might be a different one than before the restart.
I have trouble finding a fitting formulation though.

```release-note

```
