### PR TITLE
fix GHA path in dependabot.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,6 @@ updates:
           - "go.etcd.io/*"
           - "github.com/tencentcloud/*"
   - package-ecosystem: "github-actions" 
-    directory: ".github"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
At the moment, dependabot does not create PRs GHA bumps.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
